### PR TITLE
Fix flaky board test due to time-sensitive closed filter

### DIFF
--- a/app/views/board.test.js
+++ b/app/views/board.test.js
@@ -118,7 +118,7 @@ describe('views/board', () => {
         id: 'C-1',
         title: 'c1',
         updated_at: new Date('2025-10-21T09:00:00.000Z').getTime(),
-        closed_at: new Date(now - 60 * 60 * 1000).getTime(),
+        closed_at: new Date(now - 1000).getTime(),
         issue_type: 'bug'
       }
     ];


### PR DESCRIPTION
## Summary

Fixes a flaky test in `app/views/board.test.js` that fails intermittently depending on when it runs.

The board view filters closed issues to show only those closed "today" (since local midnight). The test was using `now - 60*60*1000` (1 hour ago) for the C-1 test item's `closed_at` timestamp. If the test runs shortly after midnight, this timestamp falls on the previous day and gets filtered out, causing the test to expect `['C-2', 'C-1']` but only receive `['C-2']`.

## Fix

Changed C-1's `closed_at` from `now - 60*60*1000` to `now - 1000` (1 second ago) to ensure both test items reliably fall within the "today" window regardless of when the test runs.

## Test plan

- [x] Run `npm test -- app/views/board.test.js` multiple times - passes consistently
- [x] Verified main branch fails with this timing issue
- [x] Verified fix resolves the failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)