### PR TITLE
feat: add comments to issue detail view

### DIFF
--- a/app/protocol.js
+++ b/app/protocol.js
@@ -9,7 +9,7 @@
  * - Server can also send unsolicited events (e.g., subscription `snapshot`).
  */
 
-/** @typedef {'list-issues'|'update-status'|'edit-text'|'update-priority'|'create-issue'|'list-ready'|'dep-add'|'dep-remove'|'epic-status'|'update-assignee'|'label-add'|'label-remove'|'subscribe-list'|'unsubscribe-list'|'snapshot'|'upsert'|'delete'} MessageType */
+/** @typedef {'list-issues'|'update-status'|'edit-text'|'update-priority'|'create-issue'|'list-ready'|'dep-add'|'dep-remove'|'epic-status'|'update-assignee'|'label-add'|'label-remove'|'subscribe-list'|'unsubscribe-list'|'snapshot'|'upsert'|'delete'|'get-comments'|'add-comment'} MessageType */
 
 /**
  * @typedef {Object} RequestEnvelope
@@ -53,7 +53,10 @@ export const MESSAGE_TYPES = /** @type {const} */ ([
   // vNext per-subscription full-issue push events
   'snapshot',
   'upsert',
-  'delete'
+  'delete',
+  // Comments
+  'get-comments',
+  'add-comment'
 ]);
 
 /**

--- a/app/styles.css
+++ b/app/styles.css
@@ -1656,3 +1656,67 @@ html[data-theme='dark'] {
     grid-template-columns: 1fr;
   }
 }
+
+/* Comments section */
+.comments {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.comment-item {
+  padding: 12px;
+  margin-bottom: 8px;
+  background: color-mix(in srgb, var(--panel-bg) 95%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+.comment-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+  font-size: 12px;
+}
+
+.comment-author {
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.comment-date {
+  color: var(--muted);
+}
+
+.comment-text {
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.comment-input {
+  margin-top: 12px;
+}
+
+.comment-input textarea {
+  width: 100%;
+  min-height: 60px;
+  padding: 8px;
+  border: 1px solid var(--control-border);
+  border-radius: 4px;
+  background: var(--control-bg);
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 14px;
+  resize: vertical;
+}
+
+.comment-input textarea:focus {
+  outline: none;
+  border-color: var(--link);
+}
+
+.comment-input button {
+  margin-top: 8px;
+}

--- a/app/views/detail.design.test.js
+++ b/app/views/detail.design.test.js
@@ -48,9 +48,18 @@ describe('detail view design section', () => {
       if (el.classList.contains('acceptance')) {
         return 'acceptance';
       }
+      if (el.classList.contains('comments')) {
+        return 'comments';
+      }
       return 'description';
     });
-    expect(names).toEqual(['description', 'design', 'notes', 'acceptance']);
+    expect(names).toEqual([
+      'description',
+      'design',
+      'notes',
+      'acceptance',
+      'comments'
+    ]);
     // Heading text for acceptance should be updated
     const accTitle = mount.querySelector('.acceptance .props-card__title');
     expect(accTitle && accTitle.textContent).toBe('Acceptance Criteria');

--- a/server/bd.js
+++ b/server/bd.js
@@ -5,6 +5,38 @@ import { debug } from './logging.js';
 const log = debug('bd');
 
 /**
+ * Get the git user name from git config.
+ *
+ * @param {{ cwd?: string }} [options]
+ * @returns {Promise<string>}
+ */
+export async function getGitUserName(options = {}) {
+  return new Promise((resolve) => {
+    const child = spawn('git', ['config', 'user.name'], {
+      cwd: options.cwd || process.cwd(),
+      shell: false
+    });
+
+    /** @type {string[]} */
+    const chunks = [];
+
+    if (child.stdout) {
+      child.stdout.setEncoding('utf8');
+      child.stdout.on('data', (chunk) => chunks.push(String(chunk)));
+    }
+
+    child.on('error', () => resolve(''));
+    child.on('close', (code) => {
+      if (code !== 0) {
+        resolve('');
+        return;
+      }
+      resolve(chunks.join('').trim());
+    });
+  });
+}
+
+/**
  * Resolve the bd executable path.
  *
  * @returns {string}

--- a/server/bd.test.js
+++ b/server/bd.test.js
@@ -2,7 +2,7 @@ import { spawn as spawnMock } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { getBdBin, runBd, runBdJson } from './bd.js';
+import { getBdBin, getGitUserName, runBd, runBdJson } from './bd.js';
 
 // Mock child_process.spawn before importing the module under test
 vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
@@ -89,5 +89,19 @@ describe('runBdJson', () => {
     const res = await runBdJson(['list', '--json']);
     expect(res.code).toBe(2);
     expect(res.stderr).toContain('oops');
+  });
+});
+
+describe('getGitUserName', () => {
+  test('returns git user name on success', async () => {
+    mockedSpawn.mockReturnValueOnce(makeFakeProc('Alice Smith\n', '', 0));
+    const name = await getGitUserName();
+    expect(name).toBe('Alice Smith');
+  });
+
+  test('returns empty string on failure', async () => {
+    mockedSpawn.mockReturnValueOnce(makeFakeProc('', 'error', 1));
+    const name = await getGitUserName();
+    expect(name).toBe('');
   });
 });

--- a/server/ws.comments.test.js
+++ b/server/ws.comments.test.js
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { getGitUserName, runBd, runBdJson } from './bd.js';
+import { handleMessage } from './ws.js';
+
+vi.mock('./bd.js', () => ({
+  runBd: vi.fn(),
+  runBdJson: vi.fn(),
+  getGitUserName: vi.fn()
+}));
+
+function makeStubSocket() {
+  return {
+    sent: /** @type {string[]} */ ([]),
+    readyState: 1,
+    OPEN: 1,
+    /** @param {string} msg */
+    send(msg) {
+      this.sent.push(String(msg));
+    }
+  };
+}
+
+describe('get-comments handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('returns comments array on success', async () => {
+    const rj = /** @type {import('vitest').Mock} */ (runBdJson);
+    const comments = [
+      {
+        id: 1,
+        issue_id: 'UI-1',
+        author: 'alice',
+        text: 'First comment',
+        created_at: '2025-01-01T00:00:00Z'
+      },
+      {
+        id: 2,
+        issue_id: 'UI-1',
+        author: 'bob',
+        text: 'Second comment',
+        created_at: '2025-01-02T00:00:00Z'
+      }
+    ];
+    rj.mockResolvedValueOnce({ code: 0, stdoutJson: comments });
+
+    const ws = makeStubSocket();
+    await handleMessage(
+      /** @type {any} */ (ws),
+      Buffer.from(
+        JSON.stringify({
+          id: 'req-1',
+          type: /** @type {any} */ ('get-comments'),
+          payload: { id: 'UI-1' }
+        })
+      )
+    );
+
+    expect(ws.sent.length).toBe(1);
+    const reply = JSON.parse(ws.sent[0]);
+    expect(reply.ok).toBe(true);
+    expect(reply.payload).toEqual(comments);
+
+    // Verify bd was called with correct args
+    expect(rj).toHaveBeenCalledWith(['comments', 'UI-1', '--json']);
+  });
+
+  test('returns error when issue id missing', async () => {
+    const ws = makeStubSocket();
+    await handleMessage(
+      /** @type {any} */ (ws),
+      Buffer.from(
+        JSON.stringify({
+          id: 'req-2',
+          type: /** @type {any} */ ('get-comments'),
+          payload: {}
+        })
+      )
+    );
+
+    expect(ws.sent.length).toBe(1);
+    const reply = JSON.parse(ws.sent[0]);
+    expect(reply.ok).toBe(false);
+    expect(reply.error.code).toBe('bad_request');
+  });
+
+  test('returns error when bd command fails', async () => {
+    const rj = /** @type {import('vitest').Mock} */ (runBdJson);
+    rj.mockResolvedValueOnce({ code: 1, stderr: 'Issue not found' });
+
+    const ws = makeStubSocket();
+    await handleMessage(
+      /** @type {any} */ (ws),
+      Buffer.from(
+        JSON.stringify({
+          id: 'req-3',
+          type: /** @type {any} */ ('get-comments'),
+          payload: { id: 'UI-999' }
+        })
+      )
+    );
+
+    expect(ws.sent.length).toBe(1);
+    const reply = JSON.parse(ws.sent[0]);
+    expect(reply.ok).toBe(false);
+    expect(reply.error.code).toBe('bd_error');
+  });
+});
+
+describe('add-comment handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('adds comment with git author and returns updated comments', async () => {
+    const gitUser = /** @type {import('vitest').Mock} */ (getGitUserName);
+    const rb = /** @type {import('vitest').Mock} */ (runBd);
+    const rj = /** @type {import('vitest').Mock} */ (runBdJson);
+
+    // Mock git config user.name
+    gitUser.mockResolvedValueOnce('Test User');
+    // Mock bd comment command
+    rb.mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+    // Mock bd comments --json (returns updated list)
+    const updatedComments = [
+      {
+        id: 1,
+        issue_id: 'UI-1',
+        author: 'Test User',
+        text: 'New comment',
+        created_at: '2025-01-01T00:00:00Z'
+      }
+    ];
+    rj.mockResolvedValueOnce({ code: 0, stdoutJson: updatedComments });
+
+    const ws = makeStubSocket();
+    await handleMessage(
+      /** @type {any} */ (ws),
+      Buffer.from(
+        JSON.stringify({
+          id: 'req-4',
+          type: /** @type {any} */ ('add-comment'),
+          payload: { id: 'UI-1', text: 'New comment' }
+        })
+      )
+    );
+
+    expect(ws.sent.length).toBe(1);
+    const reply = JSON.parse(ws.sent[0]);
+    expect(reply.ok).toBe(true);
+    expect(reply.payload).toEqual(updatedComments);
+
+    // Verify bd was called with correct args including --author
+    expect(rb).toHaveBeenCalledWith([
+      'comment',
+      'UI-1',
+      'New comment',
+      '--author',
+      'Test User'
+    ]);
+  });
+
+  test('adds comment without author when git user name is empty', async () => {
+    const gitUser = /** @type {import('vitest').Mock} */ (getGitUserName);
+    const rb = /** @type {import('vitest').Mock} */ (runBd);
+    const rj = /** @type {import('vitest').Mock} */ (runBdJson);
+
+    // Mock empty git user name
+    gitUser.mockResolvedValueOnce('');
+    // Mock bd comment command
+    rb.mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+    // Mock bd comments --json
+    rj.mockResolvedValueOnce({ code: 0, stdoutJson: [] });
+
+    const ws = makeStubSocket();
+    await handleMessage(
+      /** @type {any} */ (ws),
+      Buffer.from(
+        JSON.stringify({
+          id: 'req-5',
+          type: /** @type {any} */ ('add-comment'),
+          payload: { id: 'UI-1', text: 'Anonymous comment' }
+        })
+      )
+    );
+
+    expect(ws.sent.length).toBe(1);
+    const reply = JSON.parse(ws.sent[0]);
+    expect(reply.ok).toBe(true);
+
+    // Verify bd was called without --author
+    expect(rb).toHaveBeenCalledWith(['comment', 'UI-1', 'Anonymous comment']);
+  });
+
+  test('returns error when text is empty', async () => {
+    const ws = makeStubSocket();
+    await handleMessage(
+      /** @type {any} */ (ws),
+      Buffer.from(
+        JSON.stringify({
+          id: 'req-6',
+          type: /** @type {any} */ ('add-comment'),
+          payload: { id: 'UI-1', text: '' }
+        })
+      )
+    );
+
+    expect(ws.sent.length).toBe(1);
+    const reply = JSON.parse(ws.sent[0]);
+    expect(reply.ok).toBe(false);
+    expect(reply.error.code).toBe('bad_request');
+  });
+
+  test('returns error when id is missing', async () => {
+    const ws = makeStubSocket();
+    await handleMessage(
+      /** @type {any} */ (ws),
+      Buffer.from(
+        JSON.stringify({
+          id: 'req-7',
+          type: /** @type {any} */ ('add-comment'),
+          payload: { text: 'Some text' }
+        })
+      )
+    );
+
+    expect(ws.sent.length).toBe(1);
+    const reply = JSON.parse(ws.sent[0]);
+    expect(reply.ok).toBe(false);
+    expect(reply.error.code).toBe('bad_request');
+  });
+
+  test('returns error when bd comment command fails', async () => {
+    const gitUser = /** @type {import('vitest').Mock} */ (getGitUserName);
+    const rb = /** @type {import('vitest').Mock} */ (runBd);
+
+    gitUser.mockResolvedValueOnce('Test User');
+    rb.mockResolvedValueOnce({
+      code: 1,
+      stdout: '',
+      stderr: 'Issue not found'
+    });
+
+    const ws = makeStubSocket();
+    await handleMessage(
+      /** @type {any} */ (ws),
+      Buffer.from(
+        JSON.stringify({
+          id: 'req-8',
+          type: /** @type {any} */ ('add-comment'),
+          payload: { id: 'UI-999', text: 'Comment' }
+        })
+      )
+    );
+
+    expect(ws.sent.length).toBe(1);
+    const reply = JSON.parse(ws.sent[0]);
+    expect(reply.ok).toBe(false);
+    expect(reply.error.code).toBe('bd_error');
+  });
+});


### PR DESCRIPTION
   ## Overview
  This PR adds the ability to view and add comments on issues directly from the UI. Previously, comments could only be managed via the `bd comment` CLI command. Now users can see all comments on an issue and add new ones without leaving the web interface.

  **Feature highlights:**
  - Comments are displayed with author name and timestamp
  - New comments are attributed to the git user (`git config user.name`)
  - Keyboard shortcut (Ctrl/Cmd+Enter) for quick submission

  ## Summary
  - Add `get-comments` and `add-comment` WebSocket handlers on server
  - Display comments with author and timestamp in issue detail view
  - Add comment input form with Ctrl+Enter submit shortcut
  - Auto-fill author from `git config user.name`
  - Fetch comments when loading issue details

  ## Changes
  - **Server:** New handlers in `server/ws.js`, `getGitUserName` helper in `server/bd.js`
  - **Frontend:** Comments section in `app/views/detail.js` with display + input form
  - **Styles:** Comment styling in `app/styles.css`
  - **Tests:** 14 new tests (228 total, all passing)

  ## Test Plan
  - [x] Open an issue in the detail modal
  - [x] Verify "No comments yet" shows for issues without comments
  - [x] Add a comment using the textarea and "Add Comment" button
  - [x] Verify comment appears with author name and timestamp
  - [x] Verify Ctrl+Enter submits the comment
  - [x] Verify comments persist after closing and reopening the modal