### PR TITLE
fix: add windowsHide to prevent console flash on Windows

### DIFF
--- a/server/bd.js
+++ b/server/bd.js
@@ -14,7 +14,8 @@ export async function getGitUserName(options = {}) {
   return new Promise((resolve) => {
     const child = spawn('git', ['config', 'user.name'], {
       cwd: options.cwd || process.cwd(),
-      shell: false
+      shell: false,
+      windowsHide: true
     });
 
     /** @type {string[]} */
@@ -73,7 +74,8 @@ export function runBd(args, options = {}) {
   const spawn_opts = {
     cwd: options.cwd || process.cwd(),
     env: env_with_db,
-    shell: false
+    shell: false,
+    windowsHide: true
   };
 
   /** @type {string[]} */


### PR DESCRIPTION
## Problem

On Windows, every file change in the repository briefly opens and closes  a command window. This is distracting when using beads-ui.

## Root Cause

`spawn()` creates a visible console window by default for console
  applications on Windows.

## Fix

Add `windowsHide: true` to both spawn option objects in `server/bd.js`. This is a Node.js option (available since v8.8.0) that hides the subprocess console window on Windows. No effect on other platforms. Tested on Windows 10.