### PR TITLE
Add epic filter to board view

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,22 @@
 # Changes
 
+## 0.9.0
+
+- [`21fdde2`](https://github.com/mantoni/beads-ui/commit/21fdde230713a58001974db29caf288deeedb371)
+  Fix eslint warnings
+- [`5fa7fea`](https://github.com/mantoni/beads-ui/commit/5fa7fead5359aa8f01d4e12a9432464af7276e33)
+  Remove accidental bundle commit
+- [`56819d3`](https://github.com/mantoni/beads-ui/commit/56819d321b35a77da690cf028672825752b45544)
+  Add drag and drop to boards view (#30) (Brendan O'Leary)
+- [`1c52c6f`](https://github.com/mantoni/beads-ui/commit/1c52c6f2a30b7d37439f291b1a3b1d4c26510396)
+  Feature/filter toggles v2 (#20) (Frederic Haddad)
+- [`b4c7ae6`](https://github.com/mantoni/beads-ui/commit/b4c7ae62fd93d7bbaee936e0f8b659beb774122d)
+  fix: add windowsHide to prevent console flash on Windows (#29) (Titusz)
+- [`63a269e`](https://github.com/mantoni/beads-ui/commit/63a269ec1f580728bc8977d00b150d69bc1ce535)
+  feat: add multi-project workspace switching (#24) (Ofer Shaal)
+
+_Released by [Maximilian Antoni](https://github.com/mantoni) on 2026-01-02._
+
 ## 0.8.1
 
 - [`59715e8`](https://github.com/mantoni/beads-ui/commit/59715e8eb7834e6fb6ee8f63f2257da33831d705)

--- a/app/state.js
+++ b/app/state.js
@@ -20,7 +20,7 @@ import { debug } from './utils/logging.js';
  */
 
 /**
- * @typedef {{ closed_filter: ClosedFilter }} BoardState
+ * @typedef {{ closed_filter: ClosedFilter, epic_filter: string | null }} BoardState
  */
 
 /**
@@ -65,7 +65,8 @@ export function createStore(initial = {}) {
         initial.board?.closed_filter === '7' ||
         initial.board?.closed_filter === 'today'
           ? initial.board?.closed_filter
-          : 'today'
+          : 'today',
+      epic_filter: initial.board?.epic_filter ?? null
     },
     workspace: {
       current: initial.workspace?.current ?? null,
@@ -124,6 +125,7 @@ export function createStore(initial = {}) {
         next.filters.search === state.filters.search &&
         next.filters.type === state.filters.type &&
         next.board.closed_filter === state.board.closed_filter &&
+        next.board.epic_filter === state.board.epic_filter &&
         !workspace_changed
       ) {
         return;

--- a/app/styles.css
+++ b/app/styles.css
@@ -375,6 +375,7 @@ a {
 .panel__header {
   position: sticky;
   top: 0;
+  z-index: 10;
   background: inherit;
   display: flex;
   align-items: center;

--- a/app/views/board.epic-filter.test.js
+++ b/app/views/board.epic-filter.test.js
@@ -1,0 +1,286 @@
+import { describe, expect, test } from 'vitest';
+import { createSubscriptionIssueStore } from '../data/subscription-issue-store.js';
+import { createBoardView } from './board.js';
+
+function createTestIssueStores() {
+  /** @type {Map<string, any>} */
+  const stores = new Map();
+  /** @type {Set<() => void>} */
+  const listeners = new Set();
+  /**
+   * @param {string} id
+   * @returns {any}
+   */
+  function getStore(id) {
+    let s = stores.get(id);
+    if (!s) {
+      s = createSubscriptionIssueStore(id);
+      stores.set(id, s);
+      s.subscribe(() => {
+        for (const fn of Array.from(listeners)) {
+          try {
+            fn();
+          } catch {
+            /* ignore */
+          }
+        }
+      });
+    }
+    return s;
+  }
+  return {
+    getStore,
+    /** @param {string} id */
+    snapshotFor(id) {
+      return getStore(id).snapshot().slice();
+    },
+    /** @param {() => void} fn */
+    subscribe(fn) {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    }
+  };
+}
+
+describe('views/board epic filter', () => {
+  test('shows epic filter dropdown when epics are available', async () => {
+    document.body.innerHTML = '<div id="m"></div>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('m'));
+
+    const now = Date.now();
+    const issueStores = createTestIssueStores();
+
+    // Set up epics with dependents
+    issueStores.getStore('tab:epics').applyPush({
+      type: 'snapshot',
+      id: 'tab:epics',
+      revision: 1,
+      issues: [
+        {
+          id: 'EPIC-1',
+          title: 'First Epic',
+          issue_type: 'epic',
+          dependents: [{ id: 'T-1' }, { id: 'T-2' }]
+        },
+        {
+          id: 'EPIC-2',
+          title: 'Second Epic',
+          issue_type: 'epic',
+          dependents: [{ id: 'T-3' }]
+        }
+      ]
+    });
+
+    // Set up board columns
+    issueStores.getStore('tab:board:ready').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:ready',
+      revision: 1,
+      issues: [
+        { id: 'T-1', title: 'Task 1', created_at: now, updated_at: now },
+        { id: 'T-2', title: 'Task 2', created_at: now, updated_at: now },
+        { id: 'T-3', title: 'Task 3', created_at: now, updated_at: now },
+        {
+          id: 'T-4',
+          title: 'Task 4 (no epic)',
+          created_at: now,
+          updated_at: now
+        }
+      ]
+    });
+    issueStores.getStore('tab:board:blocked').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:blocked',
+      revision: 1,
+      issues: []
+    });
+    issueStores.getStore('tab:board:in-progress').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:in-progress',
+      revision: 1,
+      issues: []
+    });
+    issueStores.getStore('tab:board:closed').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:closed',
+      revision: 1,
+      issues: []
+    });
+
+    const view = createBoardView(
+      mount,
+      null,
+      () => {},
+      undefined,
+      undefined,
+      issueStores
+    );
+
+    await view.load();
+
+    // Epic filter dropdown should be visible in board header
+    const dropdown = mount.querySelector('.filter-dropdown');
+    expect(dropdown).toBeTruthy();
+
+    // Should show "Epic: All" by default
+    const trigger = mount.querySelector('.filter-dropdown__trigger');
+    expect(trigger?.textContent).toContain('Epic: All');
+
+    // Should list both epics in the menu
+    const options = mount.querySelectorAll('.filter-dropdown__option');
+    expect(options.length).toBe(3); // "All" + 2 epics
+
+    // All 4 tasks should be visible (no filter applied)
+    const ready_ids = Array.from(
+      mount.querySelectorAll('#ready-col .board-card .mono')
+    ).map((el) => el.textContent?.trim());
+    expect(ready_ids).toEqual(['T-1', 'T-2', 'T-3', 'T-4']);
+  });
+
+  test('filters board by selected epic', async () => {
+    document.body.innerHTML = '<div id="m"></div>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('m'));
+
+    const now = Date.now();
+    const issueStores = createTestIssueStores();
+
+    // Set up epics with dependents
+    issueStores.getStore('tab:epics').applyPush({
+      type: 'snapshot',
+      id: 'tab:epics',
+      revision: 1,
+      issues: [
+        {
+          id: 'EPIC-1',
+          title: 'First Epic',
+          issue_type: 'epic',
+          dependents: [{ id: 'T-1' }, { id: 'T-2' }]
+        },
+        {
+          id: 'EPIC-2',
+          title: 'Second Epic',
+          issue_type: 'epic',
+          dependents: [{ id: 'T-3' }]
+        }
+      ]
+    });
+
+    // Set up board columns
+    issueStores.getStore('tab:board:ready').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:ready',
+      revision: 1,
+      issues: [
+        { id: 'T-1', title: 'Task 1', created_at: now, updated_at: now },
+        { id: 'T-2', title: 'Task 2', created_at: now, updated_at: now },
+        { id: 'T-3', title: 'Task 3', created_at: now, updated_at: now }
+      ]
+    });
+    issueStores.getStore('tab:board:blocked').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:blocked',
+      revision: 1,
+      issues: []
+    });
+    issueStores.getStore('tab:board:in-progress').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:in-progress',
+      revision: 1,
+      issues: []
+    });
+    issueStores.getStore('tab:board:closed').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:closed',
+      revision: 1,
+      issues: []
+    });
+
+    // Create store with epic filter pre-set
+    const store = {
+      getState: () => ({
+        board: { closed_filter: 'today', epic_filter: 'EPIC-1' }
+      }),
+      setState: () => {},
+      subscribe: () => () => {}
+    };
+
+    const view = createBoardView(
+      mount,
+      null,
+      () => {},
+      store,
+      undefined,
+      issueStores
+    );
+
+    await view.load();
+
+    // Only tasks from EPIC-1 should be visible (T-1, T-2)
+    const ready_ids = Array.from(
+      mount.querySelectorAll('#ready-col .board-card .mono')
+    ).map((el) => el.textContent?.trim());
+    expect(ready_ids).toEqual(['T-1', 'T-2']);
+
+    // Count badge should reflect filtered count
+    const ready_count = mount
+      .querySelector('#ready-col .board-column__count')
+      ?.textContent?.trim();
+    expect(ready_count).toBe('2');
+  });
+
+  test('hides epic filter dropdown when no epics exist', async () => {
+    document.body.innerHTML = '<div id="m"></div>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('m'));
+
+    const now = Date.now();
+    const issueStores = createTestIssueStores();
+
+    // No epics
+    issueStores.getStore('tab:epics').applyPush({
+      type: 'snapshot',
+      id: 'tab:epics',
+      revision: 1,
+      issues: []
+    });
+
+    issueStores.getStore('tab:board:ready').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:ready',
+      revision: 1,
+      issues: [{ id: 'T-1', title: 'Task 1', created_at: now, updated_at: now }]
+    });
+    issueStores.getStore('tab:board:blocked').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:blocked',
+      revision: 1,
+      issues: []
+    });
+    issueStores.getStore('tab:board:in-progress').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:in-progress',
+      revision: 1,
+      issues: []
+    });
+    issueStores.getStore('tab:board:closed').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:closed',
+      revision: 1,
+      issues: []
+    });
+
+    const view = createBoardView(
+      mount,
+      null,
+      () => {},
+      undefined,
+      undefined,
+      issueStores
+    );
+
+    await view.load();
+
+    // No dropdown when no epics
+    const dropdown = mount.querySelector('.filter-dropdown');
+    expect(dropdown).toBeFalsy();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beads-ui",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beads-ui",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "debug": "^4.4.3",
         "dompurify": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beads-ui",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Local UI for Beads — Collaborate on issues with your coding agent.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## Summary

Adds a dropdown filter in the board header that allows filtering the board to show only issues belonging to a selected epic.

<img width="1134" height="692" alt="image" src="https://github.com/user-attachments/assets/a25ae10f-a1c4-4fcd-a9f0-54bd1bdce3d1" />


### Features
- Epic filter dropdown appears in app header (next to theme toggle)
- Defaults to "All Epics" (no filtering)
- Subscribes to epic details to get parent-child relationships
- Filters all board columns by selected epic
- Persists selection to localStorage
- Hidden when no epics exist in workspace

### Files Changed
- `app/state.js` - Added `epic_filter` to board state
- `app/views/board.js` - Epic subscription, lookup map, filter dropdown, filtering logic
- `app/main.js` - Clear epic filter when leaving board view, persist to localStorage
- `app/index.html` - Added placeholder for epic filter in header

### Test Plan
- [x] Unit tests for epic filter functionality (3 tests)
- [x] All existing tests pass (243 tests)
- [x] TypeScript, ESLint, Prettier checks pass
- [x] Manual testing with workspace containing epics