### PR TITLE
Add dependency/dependent counts to issues list view

### DIFF
--- a/app/styles.css
+++ b/app/styles.css
@@ -2093,3 +2093,27 @@ html[data-theme='dark'] {
 .btn.danger:hover {
   background: color-mix(in srgb, var(--danger, #b00020) 85%, #000);
 }
+
+/* Dependency indicators column */
+.deps-col {
+  text-align: center;
+  font-size: 13px;
+  white-space: nowrap;
+}
+.deps-indicator {
+  display: inline-flex;
+  gap: var(--space-3);
+  align-items: center;
+  font-variant-numeric: tabular-nums;
+}
+.dep-count,
+.dependent-count {
+  color: var(--muted);
+  font-family:
+    ui-monospace, 'SF Mono', Monaco, 'Cascadia Mono', 'Segoe UI Mono',
+    'Roboto Mono', Menlo, Consolas, 'Courier New', monospace;
+}
+.dep-count:hover,
+.dependent-count:hover {
+  color: var(--fg);
+}

--- a/app/views/issue-row.js
+++ b/app/views/issue-row.js
@@ -6,7 +6,7 @@ import { statusLabel } from '../utils/status.js';
 import { createTypeBadge } from '../utils/type-badge.js';
 
 /**
- * @typedef {{ id: string, title?: string, status?: string, priority?: number, issue_type?: string, assignee?: string }} IssueRowData
+ * @typedef {{ id: string, title?: string, status?: string, priority?: number, issue_type?: string, assignee?: string, dependency_count?: number, dependent_count?: number }} IssueRowData
  */
 
 /**
@@ -183,6 +183,31 @@ export function createIssueRowRenderer(options) {
               </option>`
           )}
         </select>
+      </td>
+      <td role="gridcell" class="deps-col">
+        ${(it.dependency_count || 0) > 0 || (it.dependent_count || 0) > 0
+          ? html`<span class="deps-indicator"
+              >${(it.dependency_count || 0) > 0
+                ? html`<span
+                    class="dep-count"
+                    title="${it.dependency_count} ${(it.dependency_count ||
+                      0) === 1
+                      ? 'dependency'
+                      : 'dependencies'}"
+                    >→${it.dependency_count}</span
+                  >`
+                : ''}${(it.dependent_count || 0) > 0
+                ? html`<span
+                    class="dependent-count"
+                    title="${it.dependent_count} ${(it.dependent_count || 0) ===
+                    1
+                      ? 'dependent'
+                      : 'dependents'}"
+                    >←${it.dependent_count}</span
+                  >`
+                : ''}</span
+            >`
+          : ''}
       </td>
     </tr>`;
   }

--- a/app/views/list.js
+++ b/app/views/list.js
@@ -301,6 +301,7 @@ export function createListView(
                   <col style="width: 120px" />
                   <col style="width: 160px" />
                   <col style="width: 130px" />
+                  <col style="width: 80px" />
                 </colgroup>
                 <thead>
                   <tr role="row">
@@ -310,6 +311,7 @@ export function createListView(
                     <th role="columnheader">Status</th>
                     <th role="columnheader">Assignee</th>
                     <th role="columnheader">Priority</th>
+                    <th role="columnheader">Deps</th>
                   </tr>
                 </thead>
                 <tbody role="rowgroup">


### PR DESCRIPTION
# Add dependency/dependent counts to issues list view

## Summary

This PR adds a new "Deps" column to the issues list table that displays dependency and dependent counts for each issue, making it easy to see dependency relationships at a glance without needing to open each issue.

## Features

- **Icon-based compact display**: Uses `→N` for dependencies and `←N` for dependents
- **Smart visibility**: Only shows indicators when counts are greater than zero
- **Accessible**: Includes descriptive tooltips on hover (e.g., "2 dependencies")
- **Responsive design**: Fixed 80px column width that doesn't clutter the table
- **Monospace typography**: Numbers align consistently for better readability

## Screenshots

### Issues List with Dependency Counts
The new "Deps" column appears after the Priority column:

```
| ID      | Type | Title                    | Status | Assignee | Priority | Deps   |
|---------|------|--------------------------|--------|----------|----------|--------|
| UI-80rv | task | Implement dependency ... | open   | furiosa  | P2       | →1     |
| UI-d339 | feat | Add dependency counts    | open   | furiosa  | P2       | ←1     |
```

## Implementation Details

### Data Source
- Uses existing `dependency_count` and `dependent_count` fields from `bd list --json` output
- No backend changes required - the data is already available from the beads CLI

### Files Changed
- `app/views/issue-row.js`: Added new column to row template with dependency indicators
- `app/views/list.js`: Added "Deps" header column with 80px width
- `app/styles.css`: Added CSS styling for `.deps-col`, `.deps-indicator`, `.dep-count`, and `.dependent-count`

### Technical Approach
1. Extended `IssueRowData` typedef to include optional `dependency_count` and `dependent_count` fields
2. Added conditional rendering: only show spans when counts > 0
3. Used inline-flex layout with spacing for clean visual separation
4. Applied monospace font family for consistent number alignment
5. Added hover states to highlight on mouseover

## Testing

Tested with Gas Town beads database which includes:
- Issues with dependencies (→N indicators)
- Issues with dependents (←N indicators)
- Issues with both dependencies and dependents
- Issues with no dependencies (no indicator shown)

## Benefits

1. **Improved visibility**: Users can quickly identify issues with dependencies without opening each one
2. **Better planning**: Helps identify blocking relationships and work order
3. **Reduced clicks**: No need to navigate to detail view to see dependency status
4. **Minimal clutter**: Compact design only shows relevant information

## Compatibility

- Works with existing beads data model
- Backward compatible: issues without dependency data simply show empty cell
- No breaking changes to existing functionality

## Future Enhancements (optional)

- Click on counts to filter by dependencies/dependents
- Color coding for blocked vs blocking issues
- Expand to show dependency chain on hover

---

This feature has been in use in our Gas Town beads workflow and has proven valuable for managing multi-rig dependencies across our agent coordination system.
