### PR TITLE
Hide tombstoned epics in Epics tab

### DIFF
--- a/server/list-adapters.js
+++ b/server/list-adapters.js
@@ -160,6 +160,7 @@ export async function fetchListForSubscription(spec, options = {}) {
             created_at: e.created_at,
             updated_at: e.updated_at,
             closed_at: e.closed_at ?? null,
+            deleted_at: e.deleted_at ?? null,
             // Preserve useful counters from bd output
             total_children: /** @type {any} */ (it).total_children,
             closed_children: /** @type {any} */ (it).closed_children,
@@ -168,6 +169,23 @@ export async function fetchListForSubscription(spec, options = {}) {
           return flat;
         }
         return it;
+      });
+      raw = raw.filter((it) => {
+        if (!it || typeof it !== 'object') {
+          return false;
+        }
+        const status =
+          typeof (/** @type {any} */ (it).status) === 'string'
+            ? /** @type {any} */ (it).status
+            : '';
+        if (status === 'tombstone') {
+          return false;
+        }
+        const deleted_at = /** @type {any} */ (it).deleted_at;
+        if (deleted_at !== undefined && deleted_at !== null) {
+          return false;
+        }
+        return true;
       });
     }
 

--- a/server/list-adapters.test.js
+++ b/server/list-adapters.test.js
@@ -92,6 +92,52 @@ describe('list adapters for subscription types', () => {
     }
   });
 
+  test('filters tombstoned epics', async () => {
+    /** @type {import('vitest').Mock} */ (runBdJson).mockResolvedValue({
+      code: 0,
+      stdoutJson: [
+        {
+          epic: {
+            id: 'E-1',
+            status: 'open',
+            issue_type: 'epic',
+            created_at: '2024-01-01T00:00:00.000Z',
+            updated_at: '2024-01-01T00:00:00.000Z',
+            closed_at: null
+          },
+          total_children: 1,
+          closed_children: 0,
+          eligible_for_close: false
+        },
+        {
+          epic: {
+            id: 'E-2',
+            status: 'tombstone',
+            issue_type: 'epic',
+            created_at: '2024-01-01T00:00:00.000Z',
+            updated_at: '2024-01-01T00:00:00.000Z',
+            closed_at: null,
+            deleted_at: '2024-02-01T00:00:00.000Z'
+          },
+          total_children: 0,
+          closed_children: 0,
+          eligible_for_close: false
+        }
+      ]
+    });
+
+    const res = await fetchListForSubscription({ type: 'epics' });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.items).toHaveLength(1);
+      expect(res.items[0]).toMatchObject({
+        id: 'E-1',
+        status: 'open'
+      });
+    }
+  });
+
   test('fetchListForSubscription surfaces bd error', async () => {
     /** @type {import('vitest').Mock} */ (runBdJson).mockResolvedValue({
       code: 2,


### PR DESCRIPTION
## Summary
- Filter tombstone epics returned by bd epic status --json in the list adapter.
- Keep epic counters intact while excluding deleted entries.
- Add a unit test to cover tombstone filtering.

## Rationale
`bd epic status --json` includes tombstones, which the Epics tab currently renders. Filtering in the adapter prevents deleted epics from showing up.

It's possible that we want to push this up to beads itself, but I figured that'd be more invasive and I'm not sure if there's an appetite for that. This is really minimal.

## Testing
- npm run tsc
- npm test
- npm run lint
- npm run prettier:write