### PR TITLE
Add -v/--version to bdui CLI

### DIFF
--- a/server/cli/usage.js
+++ b/server/cli/usage.js
@@ -14,6 +14,7 @@ export function printUsage(out_stream) {
     '',
     'Options:',
     '  -h, --help        Show this help message',
+    '  -v, --version     Show the CLI version',
     '  -d, --debug       Enable debug logging',
     '      --open        Open the browser after start/restart',
     '      --host <addr> Bind to a specific host (default: 127.0.0.1)',


### PR DESCRIPTION
This PR adds a -v/--version flag that prints the app version from `package.json` and exits.

- UI/CLI: update usage output to document the new flag
- Tests: extend CLI tests to cover parsing, output, and help text

Tests:

- `npm run tsc`
- `npm test`
- `npm run lint`
- `npm run prettier:write`