### PR TITLE
docs: highlight multi-workspace feature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 - ⛰️ **Epics view** – Show progress per epic, expand rows, edit inline
 - 🏂 **Board view** – Blocked / Ready / In progress / Closed columns
 - ⌨️ **Keyboard navigation** – Navigate and edit without touching the mouse
+- 🔀 **Multi-workspace** – Switch between projects via dropdown, auto-registers
+  workspaces
 
 ## Setup
 


### PR DESCRIPTION
## Summary

Add multi-workspace switching to the Features list in README.

This feature (from PR #24) is a significant capability that helps users discover they can manage multiple beads projects from a single UI instance. Currently it's not mentioned in the README, making it harder for users to discover.

## Change

Added one line to Features:
- 🔀 **Multi-workspace** – Switch between projects via dropdown, auto-registers workspaces

## Test plan

- [x] Verified feature exists and works (via PR #24 review)
- [x] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)