### PR TITLE
feat: add multi-select and bulk actions toolbar

### DIFF
--- a/app/styles.css
+++ b/app/styles.css
@@ -1007,6 +1007,23 @@ input.inline-edit:focus {
   flex: 1;
 }
 
+.bulk-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-3) var(--space-2) var(--space-3);
+  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  background: color-mix(in srgb, var(--panel-bg) 84%, transparent);
+}
+
+.bulk-toolbar__count {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  margin-right: var(--space-1);
+}
+
 /* Issues list polish */
 #list-panel .panel__body ul {
   list-style: none;
@@ -1198,6 +1215,18 @@ input.inline-edit:focus {
     font-weight: 600;
   }
 }
+
+.row-select-cell {
+  text-align: center !important;
+  padding-left: var(--space-4) !important;
+  padding-right: var(--space-4) !important;
+}
+
+.row-select-checkbox,
+.row-select-all-checkbox {
+  margin: 0;
+}
+
 .epic-row:hover {
   background: color-mix(in srgb, var(--control-bg) 55%, transparent);
 }

--- a/app/views/list.bulk-actions.test.js
+++ b/app/views/list.bulk-actions.test.js
@@ -1,0 +1,307 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createSubscriptionIssueStore } from '../data/subscription-issue-store.js';
+import { createListView } from './list.js';
+
+function createTestIssueStores() {
+  /** @type {Map<string, any>} */
+  const stores = new Map();
+  /** @type {Set<() => void>} */
+  const listeners = new Set();
+
+  /**
+   * @param {string} id
+   * @returns {any}
+   */
+  function getStore(id) {
+    let s = stores.get(id);
+    if (!s) {
+      s = createSubscriptionIssueStore(id);
+      stores.set(id, s);
+      s.subscribe(() => {
+        for (const fn of Array.from(listeners)) {
+          try {
+            fn();
+          } catch {
+            /* ignore */
+          }
+        }
+      });
+    }
+    return s;
+  }
+
+  return {
+    getStore,
+    /** @param {string} id */
+    snapshotFor(id) {
+      return getStore(id).snapshot().slice();
+    },
+    /** @param {() => void} fn */
+    subscribe(fn) {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    }
+  };
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function flushUpdates() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+/**
+ * @param {HTMLElement} mount
+ * @param {string} issue_id
+ */
+function toggleIssueCheckbox(mount, issue_id) {
+  const checkbox = /** @type {HTMLInputElement} */ (
+    mount.querySelector(
+      `tr.issue-row[data-issue-id="${issue_id}"] .row-select-checkbox`
+    )
+  );
+  checkbox.click();
+}
+
+/**
+ * @param {HTMLElement} mount
+ * @param {string} label
+ */
+function clickBulkButton(mount, label) {
+  const button = Array.from(mount.querySelectorAll('.bulk-toolbar button')).find(
+    (el) => el.textContent?.trim() === label
+  );
+  const html_button = /** @type {HTMLButtonElement} */ (button);
+  html_button.click();
+}
+
+describe('views/list bulk actions', () => {
+  test('toggles all row checkboxes from header and shows selected count', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issues = [
+      { id: 'UI-1', title: 'One', status: 'open' },
+      { id: 'UI-2', title: 'Two', status: 'open' }
+    ];
+    const issue_stores = createTestIssueStores();
+    issue_stores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues
+    });
+
+    const view = createListView(
+      mount,
+      async () => ({}),
+      undefined,
+      undefined,
+      undefined,
+      issue_stores
+    );
+    await view.load();
+
+    expect(mount.querySelector('.bulk-toolbar')).toBeNull();
+
+    const select_all = /** @type {HTMLInputElement} */ (
+      mount.querySelector('.row-select-all-checkbox')
+    );
+    select_all.click();
+
+    await flushUpdates();
+
+    const row_boxes = Array.from(
+      mount.querySelectorAll('.row-select-checkbox')
+    ).map((el) => /** @type {HTMLInputElement} */ (el).checked);
+    expect(row_boxes).toEqual([true, true]);
+    expect(mount.querySelector('.bulk-toolbar__count')?.textContent).toContain(
+      '2 issues selected'
+    );
+
+    select_all.click();
+
+    await flushUpdates();
+
+    expect(mount.querySelector('.bulk-toolbar')).toBeNull();
+  });
+
+  test('closes selected rows with one bulk action', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issues = [
+      { id: 'UI-1', title: 'One', status: 'open' },
+      { id: 'UI-2', title: 'Two', status: 'in_progress' }
+    ];
+    const issue_stores = createTestIssueStores();
+    issue_stores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues
+    });
+    const send = vi.fn(async () => ({}));
+    const view = createListView(
+      mount,
+      send,
+      undefined,
+      undefined,
+      undefined,
+      issue_stores
+    );
+    await view.load();
+
+    toggleIssueCheckbox(mount, 'UI-2');
+    clickBulkButton(mount, 'Close selected');
+
+    await flushUpdates();
+
+    const calls = send.mock.calls
+      .filter(([type]) => type === 'update-status')
+      .map(([, payload]) => payload);
+    expect(calls).toEqual([{ id: 'UI-2', status: 'closed' }]);
+  });
+
+  test('reopens selected rows with one bulk action', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issues = [
+      { id: 'UI-1', title: 'One', status: 'closed' },
+      { id: 'UI-2', title: 'Two', status: 'closed' }
+    ];
+    const issue_stores = createTestIssueStores();
+    issue_stores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues
+    });
+    const send = vi.fn(async () => ({}));
+    const view = createListView(
+      mount,
+      send,
+      undefined,
+      undefined,
+      undefined,
+      issue_stores
+    );
+    await view.load();
+
+    toggleIssueCheckbox(mount, 'UI-1');
+    toggleIssueCheckbox(mount, 'UI-2');
+    clickBulkButton(mount, 'Reopen selected');
+
+    await flushUpdates();
+
+    const calls = send.mock.calls
+      .filter(([type]) => type === 'update-status')
+      .map(([, payload]) => payload);
+    expect(calls).toEqual([
+      { id: 'UI-1', status: 'open' },
+      { id: 'UI-2', status: 'open' }
+    ]);
+  });
+
+  test('changes priority for all selected rows', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issues = [
+      { id: 'UI-1', title: 'One', status: 'open', priority: 1 },
+      { id: 'UI-2', title: 'Two', status: 'open', priority: 2 }
+    ];
+    const issue_stores = createTestIssueStores();
+    issue_stores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues
+    });
+    const send = vi.fn(async () => ({}));
+    const prompt_spy = vi.spyOn(window, 'prompt').mockReturnValue('4');
+
+    const view = createListView(
+      mount,
+      send,
+      undefined,
+      undefined,
+      undefined,
+      issue_stores
+    );
+    await view.load();
+
+    toggleIssueCheckbox(mount, 'UI-1');
+    toggleIssueCheckbox(mount, 'UI-2');
+    clickBulkButton(mount, 'Change priority');
+
+    await flushUpdates();
+
+    const calls = send.mock.calls
+      .filter(([type]) => type === 'update-priority')
+      .map(([, payload]) => payload);
+    expect(calls).toEqual([
+      { id: 'UI-1', priority: 4 },
+      { id: 'UI-2', priority: 4 }
+    ]);
+
+    prompt_spy.mockRestore();
+  });
+
+  test('edits labels across selected rows using diff operations', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issues = [
+      {
+        id: 'UI-1',
+        title: 'One',
+        status: 'open',
+        labels: ['frontend', 'legacy']
+      },
+      { id: 'UI-2', title: 'Two', status: 'open', labels: ['legacy'] }
+    ];
+    const issue_stores = createTestIssueStores();
+    issue_stores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues
+    });
+    const send = vi.fn(async () => ({}));
+    const prompt_spy = vi
+      .spyOn(window, 'prompt')
+      .mockReturnValue('frontend, backend');
+
+    const view = createListView(
+      mount,
+      send,
+      undefined,
+      undefined,
+      undefined,
+      issue_stores
+    );
+    await view.load();
+
+    toggleIssueCheckbox(mount, 'UI-1');
+    toggleIssueCheckbox(mount, 'UI-2');
+    clickBulkButton(mount, 'Edit labels');
+
+    await flushUpdates();
+
+    const calls = send.mock.calls
+      .filter(([type]) => type === 'label-add' || type === 'label-remove')
+      .map(([type, payload]) => `${type}:${payload.id}:${payload.label}`)
+      .sort();
+    expect(calls).toEqual(
+      [
+        'label-remove:UI-1:legacy',
+        'label-add:UI-1:backend',
+        'label-remove:UI-2:legacy',
+        'label-add:UI-2:frontend',
+        'label-add:UI-2:backend'
+      ].sort()
+    );
+
+    prompt_spy.mockRestore();
+  });
+});

--- a/app/views/list.navigation.test.js
+++ b/app/views/list.navigation.test.js
@@ -89,7 +89,7 @@ describe('views/list navigation', () => {
     // Focus Title cell (3rd column) in first row
     const first_title = /** @type {HTMLElement} */ (
       mount.querySelector(
-        'tbody tr.issue-row:nth-child(1) td:nth-child(3) .editable'
+        'tbody tr.issue-row:nth-child(1) td:nth-child(4) .editable'
       )
     );
     first_title.focus();
@@ -102,7 +102,7 @@ describe('views/list navigation', () => {
 
     const second_title = /** @type {HTMLElement} */ (
       mount.querySelector(
-        'tbody tr.issue-row:nth-child(2) td:nth-child(3) .editable'
+        'tbody tr.issue-row:nth-child(2) td:nth-child(4) .editable'
       )
     );
     expect(document.activeElement).toBe(second_title);
@@ -153,7 +153,7 @@ describe('views/list navigation', () => {
 
     const third_title = /** @type {HTMLElement} */ (
       mount.querySelector(
-        'tbody tr.issue-row:nth-child(3) td:nth-child(3) .editable'
+        'tbody tr.issue-row:nth-child(3) td:nth-child(4) .editable'
       )
     );
     third_title.focus();
@@ -163,7 +163,7 @@ describe('views/list navigation', () => {
 
     const second_title = /** @type {HTMLElement} */ (
       mount.querySelector(
-        'tbody tr.issue-row:nth-child(2) td:nth-child(3) .editable'
+        'tbody tr.issue-row:nth-child(2) td:nth-child(4) .editable'
       )
     );
     expect(document.activeElement).toBe(second_title);
@@ -208,7 +208,7 @@ describe('views/list navigation', () => {
     // Focus Status select (4th column) in first row
     const status_select = /** @type {HTMLSelectElement} */ (
       mount.querySelector(
-        'tbody tr.issue-row:nth-child(1) td:nth-child(4) select'
+        'tbody tr.issue-row:nth-child(1) td:nth-child(5) select'
       )
     );
     status_select.focus();
@@ -258,7 +258,7 @@ describe('views/list navigation', () => {
 
     const id_btn_row1 = /** @type {HTMLButtonElement} */ (
       mount.querySelector(
-        'tbody tr.issue-row:nth-child(1) td:nth-child(1) button'
+        'tbody tr.issue-row:nth-child(1) td:nth-child(2) button'
       )
     );
     id_btn_row1.focus();
@@ -268,7 +268,7 @@ describe('views/list navigation', () => {
 
     const id_btn_row2 = /** @type {HTMLButtonElement} */ (
       mount.querySelector(
-        'tbody tr.issue-row:nth-child(2) td:nth-child(1) button'
+        'tbody tr.issue-row:nth-child(2) td:nth-child(2) button'
       )
     );
     expect(document.activeElement).toBe(id_btn_row2);


### PR DESCRIPTION
## Summary
Adds multi-select functionality with bulk actions to the issues list view.

## Features
- Checkboxes on each issue row
- Select-all checkbox in header (with indeterminate state for partial selection)
- Bulk actions toolbar appears when items selected:
  - **Edit labels** - prompts for comma-separated labels, uses diff operations (only adds/removes changed labels)
  - **Change priority** - prompts for priority 0-4
  - **Close selected** - closes all selected issues
  - **Reopen selected** - reopens all selected issues
- Shows count of selected items
- Selection persists across filter changes (pruned to visible items)
- Toolbar disabled during bulk operations

## Tests
Added comprehensive test suite in `list.bulk-actions.test.js`:
- Toggle all checkboxes via header
- Close/reopen selected rows
- Change priority for selected
- Edit labels with diff operations

All 5 new tests pass. The 11 failing tests in CI are pre-existing issues with localStorage mocking, unrelated to this PR.

## Files Changed
- `app/views/list.js` - Main multi-select logic
- `app/views/issue-row.js` - Row checkbox
- `app/styles.css` - Bulk toolbar styling
- `app/views/list.navigation.test.js` - Updated column indices
- `app/views/list.bulk-actions.test.js` - New test file

> Recreated from https://github.com/mantoni/beads-ui/pull/50 (originally submitted from wrong account)