### PR TITLE
fix: clipboard copy fallback for non-secure contexts

### DIFF
--- a/app/utils/issue-id-renderer.js
+++ b/app/utils/issue-id-renderer.js
@@ -25,26 +25,46 @@ export function createIssueIdRenderer(id, opts) {
 
   /** Copy handler with feedback. */
   async function doCopy() {
-    // Prevent accidental row navigation and parent handlers
-    // (click/key handlers call this inside an event context)
     try {
+      let copied = false;
       if (
         navigator.clipboard &&
         typeof navigator.clipboard.writeText === 'function'
       ) {
         await navigator.clipboard.writeText(String(id));
+        copied = true;
+      } else {
+        // Fallback for non-secure contexts (HTTP, non-localhost)
+        // where navigator.clipboard is undefined.
+        const ta = document.createElement('textarea');
+        ta.value = String(id);
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        ta.style.opacity = '0';
+        // Append inside the nearest open <dialog> if any — showModal()
+        // creates a top-layer that makes document.body inert.
+        const container = btn.closest('dialog[open]') || document.body;
+        container.appendChild(ta);
+        ta.focus();
+        ta.select();
+        try {
+          copied = document.execCommand('copy');
+        } finally {
+          container.removeChild(ta);
+        }
       }
-      btn.textContent = 'Copied';
-      // Keep accessible label consistent with feedback
-      const oldAria = btn.getAttribute('aria-label') || '';
-      btn.setAttribute('aria-label', 'Copied');
-      setTimeout(
-        () => {
-          btn.textContent = id;
-          btn.setAttribute('aria-label', oldAria);
-        },
-        Math.max(80, duration)
-      );
+      if (copied) {
+        btn.textContent = 'Copied';
+        const oldAria = btn.getAttribute('aria-label') || '';
+        btn.setAttribute('aria-label', 'Copied');
+        setTimeout(
+          () => {
+            btn.textContent = id;
+            btn.setAttribute('aria-label', oldAria);
+          },
+          Math.max(80, duration)
+        );
+      }
     } catch {
       // On failure, leave text as-is; no throw to avoid disruptive UX
     }

--- a/app/utils/issue-id-renderer.test.js
+++ b/app/utils/issue-id-renderer.test.js
@@ -71,4 +71,46 @@ describe('utils/issue-id-renderer', () => {
     el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('P-42');
   });
+
+  test('falls back to execCommand when clipboard API is unavailable', async () => {
+    // Simulate non-secure context: navigator.clipboard is undefined
+    // @ts-ignore
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined
+    });
+    // jsdom does not define execCommand; provide a mock implementation
+    document.execCommand = vi.fn().mockReturnValue(true);
+
+    const el = createIssueIdRenderer('FB-1');
+    document.body.appendChild(el);
+    el.click();
+    await Promise.resolve();
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(el.textContent).toBe('Copied');
+
+    vi.advanceTimersByTime(1200);
+    expect(el.textContent).toBe('FB-1');
+    // @ts-ignore
+    delete document.execCommand;
+  });
+
+  test('does not show Copied when fallback execCommand fails', async () => {
+    // @ts-ignore
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined
+    });
+    document.execCommand = vi.fn().mockReturnValue(false);
+
+    const el = createIssueIdRenderer('FB-2');
+    document.body.appendChild(el);
+    el.click();
+    await Promise.resolve();
+
+    expect(el.textContent).toBe('FB-2');
+    // @ts-ignore
+    delete document.execCommand;
+  });
 });


### PR DESCRIPTION
## Problem

Clicking a bead ID shows "Copied" feedback but nothing is actually copied to the clipboard. This happens when beads-ui is accessed over HTTP from a non-localhost address (e.g. `http://192.168.1.12:3001`). No exceptions appear in the browser console, making the issue hard to diagnose.

Affects both Chrome and Firefox on Windows and Linux. Does not reproduce on `localhost` — which is why this was difficult to replicate from the maintainer's side.

## Root Cause

There are two separate issues:

### 1. Clipboard API is unavailable on non-secure contexts

The [Clipboard API requires a secure context](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard) (HTTPS or `localhost`). When served over plain HTTP from a LAN address, `navigator.clipboard` is `undefined`.

In `issue-id-renderer.js`, the "Copied" feedback sits **outside** the clipboard guard:

```javascript
if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
  await navigator.clipboard.writeText(String(id));
}
// This always runs — even when the block above was skipped:
btn.textContent = 'Copied';
```

When `navigator.clipboard` is `undefined`, the `if` short-circuits, no exception is thrown (so the `catch` block never fires), and execution falls through to the feedback line. The user sees "Copied" but the clipboard is untouched.

### 2. `showModal()` top-layer makes `document.body` inert

A natural fallback for the Clipboard API is `document.execCommand('copy')` with a temporary `<textarea>`. However, the issue detail view opens inside a `<dialog>` via `showModal()`, which places it in the browser's [top layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer). Elements in `document.body` become **inert** behind the modal — a `<textarea>` appended to `document.body` cannot receive focus or selection, so `execCommand('copy')` silently fails.

The fallback textarea must be appended **inside the open `<dialog>`** for it to work.

## Fix

Two changes to `issue-id-renderer.js`:

1. **"Copied" feedback is now conditional** — only shown when the copy operation actually succeeds, regardless of which code path was taken.

2. **`execCommand('copy')` fallback for non-secure contexts** — when `navigator.clipboard` is unavailable, a temporary `<textarea>` is created, populated, selected, and copied via `execCommand`. The textarea is appended to `btn.closest('dialog[open]')` if inside a modal, falling back to `document.body` otherwise.

## Testing

Two new test cases in `issue-id-renderer.test.js`:

- Fallback path copies and shows "Copied" when `navigator.clipboard` is `undefined`
- No "Copied" feedback when fallback `execCommand` returns `false`

Existing tests (3) continue to pass unchanged.

```
npm test
# 256 passed (65 files)
```

Verified manually on bdui 0.10.0, Ubuntu, accessed via `http://192.168.1.12:3001` from Chrome 143 on Windows 11 — copy works on both the board list and the detail dialog.

Fixes #37
