### PR TITLE
perf(ui): reduce subscription latency by default sandbox bd calls

### DIFF
--- a/server/bd.js
+++ b/server/bd.js
@@ -94,7 +94,7 @@ function runBdUnlocked(args, options = {}) {
   };
 
   /** @type {string[]} */
-  const final_args = args.slice();
+  const final_args = buildBdArgs(args);
 
   return new Promise((resolve) => {
     const child = spawn(bin, final_args, spawn_opts);
@@ -149,6 +149,27 @@ function runBdUnlocked(args, options = {}) {
       finish(code);
     });
   });
+}
+
+/**
+ * Build final bd CLI arguments.
+ * bdui defaults to sandbox mode to avoid sync/autopush overhead on interactive
+ * UI requests. Set `BDUI_BD_SANDBOX=0` (or "false") to opt out.
+ *
+ * @param {string[]} args
+ * @returns {string[]}
+ */
+function buildBdArgs(args) {
+  const arg_set = new Set(args);
+  const raw_sandbox = String(process.env.BDUI_BD_SANDBOX || '').toLowerCase();
+  const sandbox_disabled = raw_sandbox === '0' || raw_sandbox === 'false';
+  const should_prepend_sandbox = !sandbox_disabled && !arg_set.has('--sandbox');
+
+  if (!should_prepend_sandbox) {
+    return args.slice();
+  }
+
+  return ['--sandbox', ...args];
 }
 
 /**

--- a/server/bd.test.js
+++ b/server/bd.test.js
@@ -74,6 +74,40 @@ describe('getBdBin', () => {
 });
 
 describe('runBd', () => {
+  test('prepends --sandbox by default', async () => {
+    mockedSpawn.mockReturnValueOnce(makeFakeProc('ok', '', 0));
+    await runBd(['list', '--json']);
+
+    const args = mockedSpawn.mock.calls[0][1];
+    expect(args[0]).toBe('--sandbox');
+    expect(args.slice(1)).toEqual(['list', '--json']);
+  });
+
+  test('does not duplicate --sandbox when caller already provides it', async () => {
+    mockedSpawn.mockReturnValueOnce(makeFakeProc('ok', '', 0));
+    await runBd(['--sandbox', 'list', '--json']);
+
+    const args = mockedSpawn.mock.calls[0][1];
+    expect(args).toEqual(['--sandbox', 'list', '--json']);
+  });
+
+  test('allows disabling default sandbox via BDUI_BD_SANDBOX', async () => {
+    const prev = process.env.BDUI_BD_SANDBOX;
+    process.env.BDUI_BD_SANDBOX = '0';
+    mockedSpawn.mockReturnValueOnce(makeFakeProc('ok', '', 0));
+
+    await runBd(['list', '--json']);
+
+    const args = mockedSpawn.mock.calls[0][1];
+    expect(args).toEqual(['list', '--json']);
+
+    if (prev === undefined) {
+      delete process.env.BDUI_BD_SANDBOX;
+    } else {
+      process.env.BDUI_BD_SANDBOX = prev;
+    }
+  });
+
   test('returns stdout/stderr and exit code', async () => {
     mockedSpawn.mockReturnValueOnce(makeFakeProc('ok', '', 0));
     const res = await runBd(['--version']);


### PR DESCRIPTION
UI request paths now run bd in sandbox mode by default (--sandbox) to avoid sync/autopush overhead during interactive list subscriptions.

An opt-out is available via BDUI_BD_SANDBOX=0|false.

Benchmark summary (before → after):

Large repo with 766 closed issues:
closed-issues subscription: timed out after >90s → ~1.1s
all-issues subscription: ~20.7s → ~129ms

Medium repo with 186 closed issues:
closed-issues subscription: ~457ms → ~172ms
all-issues subscription: ~31.5s → ~113ms