### PR TITLE
fix(ui): harden daemon restart workspace registration

### DIFF
--- a/server/cli/commands.js
+++ b/server/cli/commands.js
@@ -10,6 +10,10 @@ import {
 } from './daemon.js';
 import { openUrl, registerWorkspaceWithServer, waitForServer } from './open.js';
 
+const STARTUP_SETTLE_MS = 200;
+const REGISTER_RETRY_ATTEMPTS = 5;
+const REGISTER_RETRY_DELAY_MS = 150;
+
 /**
  * Handle `start` command. Idempotent when already running.
  * - Spawns a detached server process, writes PID file, returns 0.
@@ -21,27 +25,17 @@ import { openUrl, registerWorkspaceWithServer, waitForServer } from './open.js';
 export async function handleStart(options) {
   // Default: do not open a browser unless explicitly requested via `open: true`.
   const should_open = options?.open === true;
+  const cwd = process.cwd();
   const existing_pid = readPidFile();
   if (existing_pid && isProcessRunning(existing_pid)) {
     // Server is already running - register this workspace dynamically
-    const cwd = process.cwd();
-    const workspace_database = resolveWorkspaceDatabase({ cwd });
-    if (
-      workspace_database.source !== 'home-default' &&
-      workspace_database.exists
-    ) {
-      const { url } = getConfig();
-      const registered = await registerWorkspaceWithServer(url, {
-        path: cwd,
-        database: workspace_database.path
-      });
-      if (registered) {
-        console.log('Workspace registered: %s', cwd);
-      }
+    const { url } = getConfig();
+    const registered = await registerCurrentWorkspace(url, cwd);
+    if (registered) {
+      console.log('Workspace registered: %s', cwd);
     }
     console.warn('Server is already running.');
     if (should_open) {
-      const { url } = getConfig();
       await openUrl(url);
     }
     return 0;
@@ -58,6 +52,7 @@ export async function handleStart(options) {
   if (options?.port) {
     process.env.PORT = String(options.port);
   }
+  const { url } = getConfig();
 
   const started = startDaemon({
     is_debug: options?.is_debug,
@@ -65,10 +60,32 @@ export async function handleStart(options) {
     port: options?.port
   });
   if (started && started.pid > 0) {
+    // Give the spawned daemon a brief moment to fail fast (for example EADDRINUSE).
+    await sleep(STARTUP_SETTLE_MS);
+
+    if (!isProcessRunning(started.pid)) {
+      removePidFile();
+
+      // If another server is already running at the configured URL, register this
+      // workspace there so it appears in the picker instead of silently missing.
+      const registered = await registerCurrentWorkspaceWithRetry(url, cwd);
+      if (registered) {
+        console.warn(
+          'Daemon exited early; registered workspace with existing server: %s',
+          cwd
+        );
+        return 0;
+      }
+      return 1;
+    }
+
+    // Register against the currently reachable server to ensure this workspace
+    // appears in the picker even when startup races with other daemons.
+    void registerCurrentWorkspaceWithRetry(url, cwd);
+
     printServerUrl();
     // Auto-open the browser once for a fresh daemon start
     if (should_open) {
-      const { url } = getConfig();
       // Wait briefly for the server to accept connections (single retry window)
       await waitForServer(url, 600);
       // Best-effort open; ignore result
@@ -78,6 +95,56 @@ export async function handleStart(options) {
   }
 
   return 1;
+}
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}
+
+/**
+ * @param {string} url
+ * @param {string} cwd
+ * @returns {Promise<boolean>}
+ */
+async function registerCurrentWorkspace(url, cwd) {
+  const workspace_database = resolveWorkspaceDatabase({ cwd });
+  if (
+    workspace_database.source === 'home-default' ||
+    !workspace_database.exists
+  ) {
+    return false;
+  }
+
+  return registerWorkspaceWithServer(url, {
+    path: cwd,
+    database: workspace_database.path
+  });
+}
+
+/**
+ * @param {string} url
+ * @param {string} cwd
+ * @returns {Promise<boolean>}
+ */
+async function registerCurrentWorkspaceWithRetry(url, cwd) {
+  for (let i = 0; i < REGISTER_RETRY_ATTEMPTS; i++) {
+    const registered = await registerCurrentWorkspace(url, cwd);
+    if (registered) {
+      return true;
+    }
+    if (i < REGISTER_RETRY_ATTEMPTS - 1) {
+      await sleep(REGISTER_RETRY_DELAY_MS);
+    }
+  }
+  return false;
 }
 
 /**

--- a/server/cli/commands.unit.test.js
+++ b/server/cli/commands.unit.test.js
@@ -73,6 +73,62 @@ describe('handleStart (unit)', () => {
       }
     );
   });
+
+  test('registers workspace with existing server when spawned daemon exits early', async () => {
+    const register_workspace_with_server =
+      /** @type {import('vitest').Mock} */ (open.registerWorkspaceWithServer);
+    register_workspace_with_server.mockReset();
+
+    const remove_pid = vi
+      .spyOn(daemon, 'removePidFile')
+      .mockImplementation(() => {});
+
+    vi.spyOn(daemon, 'readPidFile').mockReturnValue(null);
+    vi.spyOn(daemon, 'startDaemon').mockReturnValue({ pid: 7777 });
+    vi.spyOn(daemon, 'isProcessRunning').mockImplementation((pid) => pid === 1);
+
+    const code = await handleStart({ open: false });
+
+    expect(code).toBe(0);
+    expect(remove_pid).toHaveBeenCalledTimes(1);
+    expect(register_workspace_with_server).toHaveBeenCalledTimes(1);
+    expect(register_workspace_with_server).toHaveBeenCalledWith(
+      'http://127.0.0.1:3000',
+      {
+        path: process.cwd(),
+        database: path.join(process.cwd(), '.beads')
+      }
+    );
+  });
+
+  test('attempts workspace registration after successful daemon start', async () => {
+    const register_workspace_with_server =
+      /** @type {import('vitest').Mock} */ (open.registerWorkspaceWithServer);
+    register_workspace_with_server.mockReset();
+
+    const print_url = vi
+      .spyOn(daemon, 'printServerUrl')
+      .mockImplementation(() => {});
+
+    vi.spyOn(daemon, 'readPidFile').mockReturnValue(null);
+    vi.spyOn(daemon, 'startDaemon').mockReturnValue({ pid: 4321 });
+    vi.spyOn(daemon, 'isProcessRunning').mockImplementation(
+      (pid) => pid === 4321
+    );
+
+    const code = await handleStart({ open: false });
+
+    expect(code).toBe(0);
+    expect(print_url).toHaveBeenCalledTimes(1);
+    expect(register_workspace_with_server).toHaveBeenCalledTimes(1);
+    expect(register_workspace_with_server).toHaveBeenCalledWith(
+      'http://127.0.0.1:3000',
+      {
+        path: process.cwd(),
+        database: path.join(process.cwd(), '.beads')
+      }
+    );
+  });
 });
 
 describe('handleStop (unit)', () => {


### PR DESCRIPTION
bdui start/restart could report success while the spawned daemon exited early (for example, port race), leaving the current workspace missing from the picker.

This change:
verifies daemon liveness shortly after spawn
falls back to registering the current workspace with the active server when early-exit is detected
retries registration briefly to tolerate startup timing races
adds unit coverage for early-exit and successful-start registration paths

Result:
Workspace discovery is consistent across restart/start race conditions