### PR TITLE
fix: apply --port/--host overrides before workspace registration

### DIFF
--- a/server/cli/commands.js
+++ b/server/cli/commands.js
@@ -26,6 +26,16 @@ export async function handleStart(options) {
   // Default: do not open a browser unless explicitly requested via `open: true`.
   const should_open = options?.open === true;
   const cwd = process.cwd();
+
+  // Set env vars early so getConfig() reflects CLI overrides in ALL branches,
+  // including the "already running" path that registers workspaces via HTTP.
+  if (options?.host) {
+    process.env.HOST = options.host;
+  }
+  if (options?.port) {
+    process.env.PORT = String(options.port);
+  }
+
   const existing_pid = readPidFile();
   if (existing_pid && isProcessRunning(existing_pid)) {
     // Server is already running - register this workspace dynamically
@@ -45,13 +55,6 @@ export async function handleStart(options) {
     removePidFile();
   }
 
-  // Set env vars in current process so getConfig() reflects the overrides
-  if (options?.host) {
-    process.env.HOST = options.host;
-  }
-  if (options?.port) {
-    process.env.PORT = String(options.port);
-  }
   const { url } = getConfig();
 
   const started = startDaemon({

--- a/server/cli/commands.unit.test.js
+++ b/server/cli/commands.unit.test.js
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { handleStart, handleStop } from './commands.js';
 import * as daemon from './daemon.js';
 import * as open from './open.js';
@@ -25,10 +25,19 @@ vi.mock('../db.js', () => ({
   })
 }));
 
-// Mock config
+// Mock config - mirrors real getConfig() so env var overrides are testable
 vi.mock('../config.js', () => ({
-  getConfig: () => ({ url: 'http://127.0.0.1:3000' })
+  getConfig: () => {
+    const port = Number.parseInt(process.env.PORT || '', 10) || 3000;
+    const host = process.env.HOST || '127.0.0.1';
+    return { url: `http://${host}:${port}` };
+  }
 }));
+
+afterEach(() => {
+  delete process.env.PORT;
+  delete process.env.HOST;
+});
 
 describe('handleStart (unit)', () => {
   test('returns 1 when daemon start fails', async () => {
@@ -67,6 +76,26 @@ describe('handleStart (unit)', () => {
     expect(register_workspace_with_server).toHaveBeenCalledTimes(1);
     expect(register_workspace_with_server).toHaveBeenCalledWith(
       'http://127.0.0.1:3000',
+      {
+        path: process.cwd(),
+        database: path.join(process.cwd(), '.beads')
+      }
+    );
+  });
+
+  test('registers workspace at custom port when already running', async () => {
+    const register_workspace_with_server =
+      /** @type {import('vitest').Mock} */ (open.registerWorkspaceWithServer);
+    register_workspace_with_server.mockReset();
+    vi.spyOn(daemon, 'readPidFile').mockReturnValue(12345);
+    vi.spyOn(daemon, 'isProcessRunning').mockReturnValue(true);
+
+    const code = await handleStart({ open: false, port: 3030 });
+
+    expect(code).toBe(0);
+    expect(register_workspace_with_server).toHaveBeenCalledTimes(1);
+    expect(register_workspace_with_server).toHaveBeenCalledWith(
+      'http://127.0.0.1:3030',
       {
         path: process.cwd(),
         database: path.join(process.cwd(), '.beads')


### PR DESCRIPTION
## Summary

- When `bdui start --port <N>` is called while the server is already running, the `--port` and `--host` CLI options were applied to `process.env` **after** the "already running" early-return branch
- `getConfig()` read the unset env vars and defaulted to port 3000, so the workspace registration POST went to the wrong port and silently failed
- Moved the env var assignments before `readPidFile()` so `getConfig()` reflects CLI overrides in all code paths
- Added a unit test covering custom-port registration and made the `getConfig` mock dynamic to catch regressions

## Test plan

- [x] `npx vitest run server/cli/commands.unit.test.js` - all 9 tests pass (including new custom-port test)
- [x] `npx vitest run server/` - all 130 server tests pass
- [x] Manual: start `bdui start --port 3030` in repo A, then `bdui start --port 3030` in repo B - confirmed "Workspace registered" message and workspace appears in picker dropdownter the "already running" early-return branch. This caused getConfig() to default to port 3000, sending the workspace registration POST to the wrong port. The registration silently failed and the new workspace never appeared in the picker dropdown.
