### PR TITLE
feat(cli): preserve workspaces across bdui restart

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -4,7 +4,10 @@
 import express from 'express';
 import fs from 'node:fs';
 import path from 'node:path';
-import { registerWorkspace } from './registry-watcher.js';
+import {
+  getAvailableWorkspaces,
+  registerWorkspace
+} from './registry-watcher.js';
 
 /**
  * Create and configure the Express application.
@@ -49,6 +52,12 @@ export function createApp(config) {
     }
     registerWorkspace({ path: workspace_path, database });
     res.status(200).json({ ok: true, registered: workspace_path });
+  });
+
+  // List all known workspaces (file-based registry + in-memory)
+  app.get('/api/workspaces', (_req, res) => {
+    const workspaces = getAvailableWorkspaces();
+    res.status(200).json({ ok: true, workspaces });
   });
 
   if (

--- a/server/cli/commands.js
+++ b/server/cli/commands.js
@@ -9,7 +9,14 @@ import {
   startDaemon,
   terminateProcess
 } from './daemon.js';
-import { openUrl, registerWorkspaceWithServer, waitForServer } from './open.js';
+import {
+  fetchWorkspacesFromServer,
+  openUrl,
+  registerWorkspaceWithServer,
+  waitForServer
+} from './open.js';
+
+const RESTART_SERVER_READY_MS = 400;
 
 const STARTUP_SETTLE_MS = 200;
 const REGISTER_RETRY_ATTEMPTS = 5;
@@ -192,11 +199,16 @@ export async function handleStop() {
  * @returns {Promise<number>}
  */
 export async function handleRestart(options) {
-  // Detect the running daemon's port before stopping it.
+  // Capture state from the running server before stopping it.
   let detected_port = null;
+  /** @type {Array<{ path: string, database: string }>} */
+  let saved_workspaces = [];
   const existing_pid = readPidFile();
   if (existing_pid && isProcessRunning(existing_pid)) {
     detected_port = detectListeningPort(existing_pid);
+
+    const { url } = getConfig();
+    saved_workspaces = await fetchWorkspacesFromServer(url);
   }
 
   const stop_code = await handleStop();
@@ -212,5 +224,23 @@ export async function handleRestart(options) {
   }
 
   const start_code = await handleStart(merged_options);
-  return start_code === 0 ? 0 : 1;
+  if (start_code !== 0) {
+    return 1;
+  }
+
+  // Re-register workspaces from the previous server.
+  if (saved_workspaces.length > 0) {
+    const { url } = getConfig();
+    await waitForServer(url, RESTART_SERVER_READY_MS);
+    for (const ws of saved_workspaces) {
+      if (ws.path && ws.database) {
+        await registerWorkspaceWithServer(url, {
+          path: ws.path,
+          database: ws.database
+        });
+      }
+    }
+  }
+
+  return 0;
 }

--- a/server/cli/commands.unit.test.js
+++ b/server/cli/commands.unit.test.js
@@ -8,6 +8,7 @@ import * as open from './open.js';
 vi.mock('./open.js', () => ({
   openUrl: async () => true,
   waitForServer: async () => {},
+  fetchWorkspacesFromServer: vi.fn(async () => []),
   registerWorkspaceWithServer: vi.fn(async () => true)
 }));
 
@@ -275,5 +276,46 @@ describe('handleRestart (unit)', () => {
     expect(start_daemon.mock.calls[0]?.[0]).toEqual(
       expect.not.objectContaining({ port: expect.any(Number) })
     );
+  });
+
+  test('re-registers workspaces from previous server after restart', async () => {
+    const fetch_workspaces = /** @type {import('vitest').Mock} */ (
+      open.fetchWorkspacesFromServer
+    );
+    fetch_workspaces.mockResolvedValueOnce([
+      { path: '/project/a', database: '/project/a/.beads' },
+      { path: '/project/b', database: '/project/b/.beads' }
+    ]);
+
+    const register_workspace = /** @type {import('vitest').Mock} */ (
+      open.registerWorkspaceWithServer
+    );
+    register_workspace.mockReset();
+
+    vi.spyOn(daemon, 'readPidFile')
+      .mockReturnValueOnce(3333) // restart: detect port
+      .mockReturnValueOnce(3333) // handleStop: find process
+      .mockReturnValueOnce(null); // handleStart: no existing
+    vi.spyOn(daemon, 'detectListeningPort').mockReturnValue(null);
+    vi.spyOn(daemon, 'isProcessRunning').mockImplementation(
+      (pid) => pid === 3333 || pid === 9999
+    );
+    vi.spyOn(daemon, 'terminateProcess').mockResolvedValue(true);
+    vi.spyOn(daemon, 'removePidFile').mockImplementation(() => {});
+    vi.spyOn(daemon, 'printServerUrl').mockImplementation(() => {});
+    vi.spyOn(daemon, 'startDaemon').mockReturnValue({ pid: 9999 });
+
+    const code = await handleRestart();
+
+    expect(code).toBe(0);
+    // The cwd workspace is registered by handleStart, plus the two saved ones
+    expect(register_workspace).toHaveBeenCalledWith('http://127.0.0.1:3000', {
+      path: '/project/a',
+      database: '/project/a/.beads'
+    });
+    expect(register_workspace).toHaveBeenCalledWith('http://127.0.0.1:3000', {
+      path: '/project/b',
+      database: '/project/b/.beads'
+    });
   });
 });

--- a/server/cli/open.js
+++ b/server/cli/open.js
@@ -99,6 +99,45 @@ function sleep(ms) {
 }
 
 /**
+ * Fetch the list of workspaces from the running server.
+ *
+ * @param {string} base_url - Server base URL (e.g., "http://127.0.0.1:3000")
+ * @returns {Promise<Array<{ path: string, database: string }>>}
+ */
+export async function fetchWorkspacesFromServer(base_url) {
+  return new Promise((resolve) => {
+    const url = new URL('/api/workspaces', base_url);
+    const req = http.get(url, (res) => {
+      let data = '';
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+      res.on('end', () => {
+        try {
+          const parsed = JSON.parse(data);
+          if (parsed.ok && Array.isArray(parsed.workspaces)) {
+            resolve(parsed.workspaces);
+          } else {
+            resolve([]);
+          }
+        } catch {
+          resolve([]);
+        }
+      });
+    });
+    req.on('error', () => resolve([]));
+    req.setTimeout(2000, () => {
+      try {
+        req.destroy();
+      } catch {
+        void 0;
+      }
+      resolve([]);
+    });
+  });
+}
+
+/**
  * Register a workspace with the running server.
  * Makes a POST request to /api/register-workspace.
  *


### PR DESCRIPTION
## Summary

When you run `bdui restart` from a different directory, the workspace picker loses all previously registered workspaces. The server only knows about the current directory and whatever is in the stale `~/.beads/registry.json` file. Switch directories a couple times and you're down to one workspace in the picker.

This fixes it by capturing the workspace list from the running server before stopping it, then re-registering them after the new server starts. Same pattern as the port detection — read state before stop, restore after start.

- Add `GET /api/workspaces` endpoint to expose the merged workspace list over HTTP
- Add `fetchWorkspacesFromServer` to the CLI client
- `handleRestart` fetches workspaces before stop, re-registers after start

## Test plan

- [x] Unit test: verifies saved workspaces are re-registered after restart
- [x] All 268 tests pass on Node 22 and 24
- [x] Manual testing with playwright-cli: start from beads-ui, restart from falcon-backend, restart from thrum — all three workspaces preserved in the picker every time