### PR TITLE
feat(cli): auto-increment port when default is in use

### DIFF
--- a/server/cli/commands.js
+++ b/server/cli/commands.js
@@ -2,6 +2,7 @@ import { getConfig } from '../config.js';
 import { resolveWorkspaceDatabase } from '../db.js';
 import {
   detectListeningPort,
+  findAvailablePort,
   isProcessRunning,
   printServerUrl,
   readPidFile,
@@ -56,12 +57,50 @@ export async function handleStart(options) {
     removePidFile();
   }
 
+  const { port: config_port, host: config_host } = getConfig();
+
+  // When the user did not pass an explicit --port, check whether the default
+  // port is already in use. If something is already listening, try to register
+  // with it first — it may be an existing bdui instance we can reuse.
+  // Only auto-increment to the next port if registration fails.
+  let effective_port = options?.port;
+  if (!effective_port) {
+    const available = await findAvailablePort(config_port, config_host);
+    if (available === null) {
+      console.error(
+        'No available port found (tried %d–%d).',
+        config_port,
+        config_port + 9
+      );
+      return 1;
+    }
+    if (available !== config_port) {
+      // Default port is busy — try to register with whatever is there.
+      const existing_url = `http://${config_host}:${config_port}`;
+      const registered = await registerCurrentWorkspace(existing_url, cwd);
+      if (registered) {
+        console.log('Workspace registered with existing server: %s', cwd);
+        if (should_open) {
+          await openUrl(existing_url);
+        }
+        return 0;
+      }
+      // Not a bdui instance — auto-increment to the next available port.
+      console.log('Port %d in use, using %d instead.', config_port, available);
+      effective_port = available;
+    }
+  }
+
+  // Set PORT env so getConfig() returns the correct URL for registration
+  if (effective_port) {
+    process.env.PORT = String(effective_port);
+  }
   const { url } = getConfig();
 
   const started = startDaemon({
     is_debug: options?.is_debug,
     host: options?.host,
-    port: options?.port
+    port: effective_port
   });
   if (started && started.pid > 0) {
     // Give the spawned daemon a brief moment to fail fast (for example EADDRINUSE).

--- a/server/cli/commands.unit.test.js
+++ b/server/cli/commands.unit.test.js
@@ -30,7 +30,7 @@ vi.mock('../config.js', () => ({
   getConfig: () => {
     const port = Number.parseInt(process.env.PORT || '', 10) || 3000;
     const host = process.env.HOST || '127.0.0.1';
-    return { url: `http://${host}:${port}` };
+    return { host, port, url: `http://${host}:${port}` };
   }
 }));
 
@@ -43,6 +43,7 @@ describe('handleStart (unit)', () => {
   test('returns 1 when daemon start fails', async () => {
     vi.spyOn(daemon, 'readPidFile').mockReturnValue(null);
     vi.spyOn(daemon, 'isProcessRunning').mockReturnValue(false);
+    vi.spyOn(daemon, 'findAvailablePort').mockResolvedValue(3000);
     vi.spyOn(daemon, 'startDaemon').mockReturnValue(null);
 
     const code = await handleStart({ open: false });
@@ -113,6 +114,7 @@ describe('handleStart (unit)', () => {
       .mockImplementation(() => {});
 
     vi.spyOn(daemon, 'readPidFile').mockReturnValue(null);
+    vi.spyOn(daemon, 'findAvailablePort').mockResolvedValue(3000);
     vi.spyOn(daemon, 'startDaemon').mockReturnValue({ pid: 7777 });
     vi.spyOn(daemon, 'isProcessRunning').mockImplementation((pid) => pid === 1);
 
@@ -140,6 +142,7 @@ describe('handleStart (unit)', () => {
       .mockImplementation(() => {});
 
     vi.spyOn(daemon, 'readPidFile').mockReturnValue(null);
+    vi.spyOn(daemon, 'findAvailablePort').mockResolvedValue(3000);
     vi.spyOn(daemon, 'startDaemon').mockReturnValue({ pid: 4321 });
     vi.spyOn(daemon, 'isProcessRunning').mockImplementation(
       (pid) => pid === 4321
@@ -207,6 +210,7 @@ describe('handleRestart (unit)', () => {
       .mockReturnValueOnce(3333) // handleStop: find process
       .mockReturnValueOnce(null); // handleStart: no existing
     vi.spyOn(daemon, 'detectListeningPort').mockReturnValue(4000);
+    vi.spyOn(daemon, 'findAvailablePort').mockResolvedValue(4000);
     vi.spyOn(daemon, 'isProcessRunning').mockImplementation(
       (pid) => pid === 3333 || pid === 5555
     );
@@ -237,7 +241,6 @@ describe('handleRestart (unit)', () => {
     );
     vi.spyOn(daemon, 'terminateProcess').mockResolvedValue(true);
     vi.spyOn(daemon, 'removePidFile').mockImplementation(() => {});
-    vi.spyOn(daemon, 'printServerUrl').mockImplementation(() => {});
 
     const start_daemon = vi
       .spyOn(daemon, 'startDaemon')
@@ -257,6 +260,7 @@ describe('handleRestart (unit)', () => {
       .mockReturnValueOnce(3333)
       .mockReturnValueOnce(null);
     vi.spyOn(daemon, 'detectListeningPort').mockReturnValue(null);
+    vi.spyOn(daemon, 'findAvailablePort').mockResolvedValue(3000);
     vi.spyOn(daemon, 'isProcessRunning').mockImplementation(
       (pid) => pid === 3333 || pid === 7777
     );
@@ -275,5 +279,88 @@ describe('handleRestart (unit)', () => {
     expect(start_daemon.mock.calls[0]?.[0]).toEqual(
       expect.not.objectContaining({ port: expect.any(Number) })
     );
+  });
+});
+
+describe('port auto-increment (unit)', () => {
+  test('auto-increments port when default is in use by non-bdui', async () => {
+    const register_workspace = /** @type {import('vitest').Mock} */ (
+      open.registerWorkspaceWithServer
+    );
+    // Registration fails — not a bdui instance on that port
+    register_workspace.mockResolvedValueOnce(false);
+
+    vi.spyOn(daemon, 'readPidFile').mockReturnValue(null);
+    vi.spyOn(daemon, 'findAvailablePort').mockResolvedValue(3001);
+    vi.spyOn(daemon, 'isProcessRunning').mockImplementation(
+      (pid) => pid === 8888
+    );
+    vi.spyOn(daemon, 'printServerUrl').mockImplementation(() => {});
+
+    const start_daemon = vi
+      .spyOn(daemon, 'startDaemon')
+      .mockReturnValue({ pid: 8888 });
+
+    const code = await handleStart({ open: false });
+
+    expect(code).toBe(0);
+    expect(start_daemon).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 3001 })
+    );
+  });
+
+  test('reuses existing bdui when default port is occupied', async () => {
+    const register_workspace = /** @type {import('vitest').Mock} */ (
+      open.registerWorkspaceWithServer
+    );
+    // Registration succeeds — existing bdui on that port
+    register_workspace.mockResolvedValueOnce(true);
+
+    vi.spyOn(daemon, 'readPidFile').mockReturnValue(null);
+    vi.spyOn(daemon, 'findAvailablePort').mockResolvedValue(3001);
+
+    const start_daemon = vi
+      .spyOn(daemon, 'startDaemon')
+      .mockReturnValue({ pid: 8888 });
+
+    const code = await handleStart({ open: false });
+
+    expect(code).toBe(0);
+    // Should NOT have started a new daemon — reused existing
+    expect(start_daemon).not.toHaveBeenCalled();
+  });
+
+  test('does not auto-increment when explicit port is given', async () => {
+    vi.spyOn(daemon, 'readPidFile').mockReturnValue(null);
+    vi.spyOn(daemon, 'isProcessRunning').mockImplementation(
+      (pid) => pid === 8888
+    );
+    vi.spyOn(daemon, 'printServerUrl').mockImplementation(() => {});
+
+    const find_port = vi
+      .spyOn(daemon, 'findAvailablePort')
+      .mockResolvedValue(5000);
+
+    const start_daemon = vi
+      .spyOn(daemon, 'startDaemon')
+      .mockReturnValue({ pid: 8888 });
+
+    const code = await handleStart({ open: false, port: 5000 });
+
+    expect(code).toBe(0);
+    // findAvailablePort should not be called when port is explicit
+    expect(find_port).not.toHaveBeenCalled();
+    expect(start_daemon).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 5000 })
+    );
+  });
+
+  test('returns 1 when no port is available', async () => {
+    vi.spyOn(daemon, 'readPidFile').mockReturnValue(null);
+    vi.spyOn(daemon, 'findAvailablePort').mockResolvedValue(null);
+
+    const code = await handleStart({ open: false });
+
+    expect(code).toBe(1);
   });
 });

--- a/server/cli/daemon.js
+++ b/server/cli/daemon.js
@@ -3,6 +3,7 @@
  */
 import { execFileSync, spawn } from 'node:child_process';
 import fs from 'node:fs';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -285,6 +286,41 @@ export function detectListeningPort(pid) {
     }
   } catch {
     // lsof not available or process gone — fall through
+  }
+  return null;
+}
+
+/**
+ * Check whether a TCP port is available on the given host.
+ *
+ * @param {number} port
+ * @param {string} host
+ * @returns {Promise<boolean>}
+ */
+export function isPortAvailable(port, host) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.listen(port, host, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+/**
+ * Starting from `port`, find the first available port on `host`.
+ * Tries up to `max_attempts` consecutive ports.
+ *
+ * @param {number} port
+ * @param {string} host
+ * @param {number} [max_attempts]
+ * @returns {Promise<number | null>}
+ */
+export async function findAvailablePort(port, host, max_attempts = 10) {
+  for (let i = 0; i < max_attempts; i++) {
+    if (await isPortAvailable(port + i, host)) {
+      return port + i;
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Summary

If something else is already listening on port 3000, `bdui start` silently fails — the daemon exits early and you get a cryptic "registered workspace with existing server" message. You have to figure out the port conflict yourself and pass `--port`.

This fixes it by checking whether the default port is available before spawning the daemon. If the port is taken, bdui first tries to register with whatever is there — if it's an existing bdui instance, it reuses it instead of starting a second one. If it's not bdui, it tries the next port, up to 10 attempts.

```
$ bdui start
Port 3000 in use, using 3001 instead.
beads ui   listening on http://127.0.0.1:3001
```

Explicit `--port` skips all of this — you asked for that port, you get that port.

- `isPortAvailable` / `findAvailablePort` in daemon.js using Node's `net` module
- When default port is busy, probe it via `register-workspace` before giving up on it
- Falls through to auto-increment only when the occupant isn't a bdui instance
- Gives up after 10 consecutive ports with a clear error message

## Test plan

- [x] Unit tests: auto-increment on non-bdui, reuse existing bdui, explicit port bypass, no-port-available error
- [x] All 271 tests pass on Node 22 and 24
- [x] Manual testing: blocked port 3000 with a dummy server, `bdui start` auto-selected 3001