### PR TITLE
fix(ws): pass cwd to all runBd/runBdJson mutation handlers 

### DIFF
--- a/server/ws.comments.test.js
+++ b/server/ws.comments.test.js
@@ -63,7 +63,7 @@ describe('get-comments handler', () => {
     expect(reply.payload).toEqual(comments);
 
     // Verify bd was called with correct args
-    expect(rj).toHaveBeenCalledWith(['comments', 'UI-1', '--json']);
+    expect(rj).toHaveBeenCalledWith(['comments', 'UI-1', '--json'], { cwd: undefined });
   });
 
   test('returns error when issue id missing', async () => {
@@ -158,7 +158,7 @@ describe('add-comment handler', () => {
       'New comment',
       '--author',
       'Test User'
-    ]);
+    ], { cwd: undefined });
   });
 
   test('adds comment without author when git user name is empty', async () => {
@@ -190,7 +190,7 @@ describe('add-comment handler', () => {
     expect(reply.ok).toBe(true);
 
     // Verify bd was called without --author
-    expect(rb).toHaveBeenCalledWith(['comment', 'UI-1', 'Anonymous comment']);
+    expect(rb).toHaveBeenCalledWith(['comment', 'UI-1', 'Anonymous comment'], { cwd: undefined });
   });
 
   test('returns error when text is empty', async () => {

--- a/server/ws.delete.test.js
+++ b/server/ws.delete.test.js
@@ -42,7 +42,7 @@ describe('delete-issue handler', () => {
     );
 
     // Check bd delete was called with --force
-    expect(rb).toHaveBeenCalledWith(['delete', 'beads-abc123', '--force']);
+    expect(rb).toHaveBeenCalledWith(['delete', 'beads-abc123', '--force'], { cwd: undefined });
 
     // Check response
     expect(ws.sent.length).toBe(1);

--- a/server/ws.js
+++ b/server/ws.js
@@ -749,14 +749,14 @@ export async function handleMessage(ws, data) {
       return;
     }
     // Pass empty string to clear assignee when requested
-    const res = await runBd(['update', id, '--assignee', assignee]);
+    const res = await runBd(['update', id, '--assignee', assignee], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
       );
       return;
     }
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -794,14 +794,14 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['update', id, '--status', status]);
+    const res = await runBd(['update', id, '--status', status], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
       );
       return;
     }
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -840,14 +840,14 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['update', id, '--priority', String(priority)]);
+    const res = await runBd(['update', id, '--priority', String(priority)], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
       );
       return;
     }
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -904,14 +904,14 @@ export async function handleMessage(ws, data) {
             : field === 'notes'
               ? '--notes'
               : '--design';
-    const res = await runBd(['update', id, flag, value]);
+    const res = await runBd(['update', id, flag, value], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
       );
       return;
     }
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -962,7 +962,7 @@ export async function handleMessage(ws, data) {
     if (typeof description === 'string' && description.length > 0) {
       args.push('-d', description);
     }
-    const res = await runBd(args);
+    const res = await runBd(args, { cwd: CURRENT_WORKSPACE?.root_dir });
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
@@ -1000,7 +1000,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['dep', 'add', a, b]);
+    const res = await runBd(['dep', 'add', a, b], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
@@ -1008,7 +1008,7 @@ export async function handleMessage(ws, data) {
       return;
     }
     const id = typeof view_id === 'string' && view_id.length > 0 ? view_id : a;
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -1044,7 +1044,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['dep', 'remove', a, b]);
+    const res = await runBd(['dep', 'remove', a, b], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
@@ -1052,7 +1052,7 @@ export async function handleMessage(ws, data) {
       return;
     }
     const id = typeof view_id === 'string' && view_id.length > 0 ? view_id : a;
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -1088,14 +1088,14 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['label', 'add', id, label.trim()]);
+    const res = await runBd(['label', 'add', id, label.trim()], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
       );
       return;
     }
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -1131,14 +1131,14 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['label', 'remove', id, label.trim()]);
+    const res = await runBd(['label', 'remove', id, label.trim()], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
       );
       return;
     }
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -1165,7 +1165,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBdJson(['comments', id, '--json']);
+    const res = await runBdJson(['comments', id, '--json'], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
@@ -1204,7 +1204,7 @@ export async function handleMessage(ws, data) {
       args.push('--author', author);
     }
 
-    const res = await runBd(args);
+    const res = await runBd(args, { cwd: CURRENT_WORKSPACE?.root_dir });
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
@@ -1213,7 +1213,7 @@ export async function handleMessage(ws, data) {
     }
 
     // Return updated comments list
-    const comments = await runBdJson(['comments', id, '--json']);
+    const comments = await runBdJson(['comments', id, '--json'], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (comments.code !== 0) {
       ws.send(
         JSON.stringify(
@@ -1237,7 +1237,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['delete', id, '--force']);
+    const res = await runBd(['delete', id, '--force'], { cwd: CURRENT_WORKSPACE?.root_dir });
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(


### PR DESCRIPTION
  ## Problem                                                                                   
                                         
  When using multi-workspace setups, all mutation handlers in `ws.js` (update, create,                                                                       
  delete, comments, labels, dependencies) spawn `bd` without passing the current
  workspace's `cwd`. This causes `bd` to resolve the wrong database — either falling                                                                         
  back to the server's working directory or failing entirely — so mutations silently                                                                         
  affect the wrong project or produce `bd_error` responses.                                                                                                  
                                                                                                                                                             
  The read path (subscriptions, `fetchListForSubscription`) already passes                                                                                   
  `{ cwd: CURRENT_WORKSPACE?.root_dir }` correctly. Only the write path was missing it.                                                                      
                                                                                                                                                             
  ## Fix                                                                                       
                                                                                                                                                             
  Add `{ cwd: CURRENT_WORKSPACE?.root_dir }` to all 21 `runBd()` / `runBdJson()` calls                                                                       
  in the mutation handlers:              
                                                                                                                                                             
  - `update-assignee`, `update-status`, `update-priority`, `edit-field`                                                                                      
  - `create-issue`         
  - `add-dep`, `remove-dep`                                                                                                                                  
  - `add-label`, `remove-label`                                                                
  - `list-comments`, `add-comment`                                                                                                                           
  - `delete-issue`
                                                                                                                                                             
  Tests updated accordingly. 