### PR TITLE
fix(ws): use correctabdtsubcommand for adding comments

### DIFF
--- a/server/ws.comments.test.js
+++ b/server/ws.comments.test.js
@@ -153,7 +153,8 @@ describe('add-comment handler', () => {
 
     // Verify bd was called with correct args including --author
     expect(rb).toHaveBeenCalledWith([
-      'comment',
+      'comments',
+      'add',
       'UI-1',
       'New comment',
       '--author',
@@ -190,7 +191,7 @@ describe('add-comment handler', () => {
     expect(reply.ok).toBe(true);
 
     // Verify bd was called without --author
-    expect(rb).toHaveBeenCalledWith(['comment', 'UI-1', 'Anonymous comment']);
+    expect(rb).toHaveBeenCalledWith(['comments', 'add', 'UI-1', 'Anonymous comment']);
   });
 
   test('returns error when text is empty', async () => {

--- a/server/ws.js
+++ b/server/ws.js
@@ -1199,7 +1199,7 @@ export async function handleMessage(ws, data) {
 
     // Get git user name for author attribution
     const author = await getGitUserName();
-    const args = ['comment', id, text.trim()];
+    const args = ['comments', 'add', id, text.trim()];
     if (author) {
       args.push('--author', author);
     }


### PR DESCRIPTION
Fixes #74                                                                                                                                                  
                                                                                                                                                             
  ## Problem
                                                                                                                                                             
  Creating comments from the UI fails because the WebSocket handler uses the                                                                                 
  old `bd comment <id> <text>` subcommand, which no longer exists in recent
  bd versions. The CLI works fine because it uses the correct command directly.                                                                              
                                                                                                                                                             
  ## Fix                                                                                                                                                     
                                                                                                                                                             
  Change the `add-comment` handler in `ws.js` from:                                                                                                        
                           
      bd comment <id> <text>                                                                                                                                 
                                         
  to:                                                                                                                                                        
                                                                                                                                                           
      bd comments add <id> <text>
           
  This matches the current bd CLI interface (tested with bd 0.63.3). 