### PR TITLE
feat(cli): print server URL on start/restart when reusing existing server

### DIFF
--- a/server/cli/commands.js
+++ b/server/cli/commands.js
@@ -54,6 +54,7 @@ export async function handleStart(options) {
       console.log('Workspace registered: %s', cwd);
     }
     console.warn('Server is already running.');
+    console.log('beads ui   listening on %s', url);
     if (should_open) {
       await openUrl(url);
     }
@@ -87,6 +88,7 @@ export async function handleStart(options) {
       const registered = await registerCurrentWorkspace(existing_url, cwd);
       if (registered) {
         console.log('Workspace registered with existing server: %s', cwd);
+        console.log('beads ui   listening on %s', existing_url);
         if (should_open) {
           await openUrl(existing_url);
         }
@@ -124,6 +126,7 @@ export async function handleStart(options) {
           'Daemon exited early; registered workspace with existing server: %s',
           cwd
         );
+        console.log('beads ui   listening on %s', url);
         return 0;
       }
       return 1;


### PR DESCRIPTION
## Summary
- When `bdui restart` (or `start`) finds another bdui already listening and registers this workspace with it, print a `beads ui   listening on <url>` line so the URL is clickable in the terminal.
- Before: `bdui restart` output ended at `Workspace registered with existing server: …` with no URL.
- Covers three existing reuse paths: already-running check, default-port-busy-registered-with-existing, and daemon-exited-early fallback.

## Test plan
- [x] `npm test` — all 272 tests pass
- [ ] Manual: `bdui restart` in a workspace where another bdui is running prints the URL