### PR TITLE
fix(app): resolve WebSocket and bundle paths relatively for subpath mounts

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -44,6 +44,6 @@
       </div>
     </header>
     <main id="app" class="app-shell" aria-live="polite"></main>
-    <script type="module" src="/main.bundle.js"></script>
+    <script type="module" src="main.bundle.js"></script>
   </body>
 </html>

--- a/app/ws.js
+++ b/app/ws.js
@@ -47,9 +47,16 @@ export function createWsClient(options = {}) {
       return options.url;
     }
     if (typeof location !== 'undefined') {
+      // Derive the WS path from the current document's directory so the
+      // client works whether mounted at `/` or behind a reverse-proxy
+      // subpath like `/backlog/`. `pathname` will be `/` or `/subpath/`
+      // (the server always serves the SPA shell at a directory URL), so
+      // stripping the trailing filename (if any) yields the mount dir.
+      const base_path = location.pathname.replace(/\/[^/]*$/, '');
       return (
         (location.protocol === 'https:' ? 'wss://' : 'ws://') +
         location.host +
+        base_path +
         '/ws'
       );
     }


### PR DESCRIPTION
## Problem

`bdui` currently assumes it is mounted at `/`. Two hardcoded absolute paths in the SPA escape any reverse-proxy subpath:

- `app/index.html` — `<script type="module" src="/main.bundle.js">`
- `app/ws.js` — WebSocket URL hardcoded as `location.host + '/ws'`

When an operator reverse-proxies `bdui` at, e.g., `https://example.com/backlog/` (Caddy, nginx, Traefik — the usual homelab front door patterns), the browser resolves those absolute paths against the proxy root, not the mount point. The bundle request and WS handshake both miss the proxy's strip-prefix rewrite and land on whatever catch-all lives at `/`.

Concrete symptom we hit: `bdui` mounted behind Caddy's `handle_path /backlog/* { reverse_proxy <upstream> }` — the HTML loads fine (relative `./styles.css` works), but `/main.bundle.js` 404s and the WS connection falls through to the wrong upstream.

## Fix

Two one-line changes to make both paths relative to the current document.

- `app/index.html`: drop the leading slash from the `<script src>` so the bundle resolves against the current directory.
- `app/ws.js`: derive a `base_path` from `location.pathname` (strip the trailing filename if any — at `/` that yields `''`, at `/backlog/` it yields `/backlog`) and build the WS URL as `host + base_path + '/ws'`. The `/ws` endpoint is then a sibling of the current document regardless of mount point.

No server-side changes are required. The proxy's normal `strip_prefix` handles the upstream rewrite:

```
# Caddy
handle_path /backlog/* {
    reverse_proxy 127.0.0.1:3000
}
```

## Compatibility

At mount point `/` the patched client produces identical URLs to the old client:

- `location.pathname` is `/` → `base_path` = `''` → WS URL = `host + '' + '/ws'` = `host/ws` (unchanged)
- `<script src=\"main.bundle.js\">` resolved from `/` yields `/main.bundle.js` (unchanged)

All 272 existing vitest tests pass unchanged on this branch.

## Verified end-to-end

Tested against a real Caddy reverse-proxy mount at `/backlog/*` with WebSocket upgrade — HTTP 200 for HTML, bundle, styles, `/api/workspaces`, and HTTP 101 Switching Protocols for the WS handshake. The full SPA (issues/epics/board views, search, create-issue) works correctly at the subpath.

Made with [Cursor](https://cursor.com)