### PR TITLE
fix(server): watch embedded Dolt path instead of .beads metadata dir

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -50,12 +50,16 @@ export function resolveDbPath(options = {}) {
 /**
  * Resolve the workspace database location used by the UI/server.
  *
- * For non-SQLite backends (for example Dolt), this returns the nearest
- * workspace `.beads` directory when metadata exists. This avoids collapsing
- * all such workspaces onto the `~/.beads/default.db` fallback.
+ * For embedded-Dolt workspaces, this resolves the nearest
+ * `.beads/embeddeddolt/` directory so downstream watchers can target the
+ * actual database path instead of the noisy `.beads/` parent directory.
+ *
+ * For other non-SQLite backends, this returns the nearest workspace `.beads`
+ * directory when metadata exists. This avoids collapsing all such workspaces
+ * onto the `~/.beads/default.db` fallback.
  *
  * @param {{ cwd?: string, env?: Record<string, string | undefined>, explicit_db?: string }} [options]
- * @returns {{ path: string, source: 'flag'|'env'|'nearest'|'metadata'|'home-default', exists: boolean }}
+ * @returns {{ path: string, source: 'flag'|'env'|'nearest'|'embedded-dolt'|'metadata'|'home-default', exists: boolean }}
  */
 export function resolveWorkspaceDatabase(options = {}) {
   const sqlite_db = resolveDbPath(options);
@@ -64,6 +68,15 @@ export function resolveWorkspaceDatabase(options = {}) {
   }
 
   const cwd = options.cwd ? path.resolve(options.cwd) : process.cwd();
+  const embedded_dolt_path = findNearestEmbeddedDolt(cwd);
+  if (embedded_dolt_path) {
+    return {
+      path: embedded_dolt_path,
+      source: 'embedded-dolt',
+      exists: true
+    };
+  }
+
   const metadata_path = findNearestBeadsMetadata(cwd);
   if (metadata_path) {
     return {
@@ -74,6 +87,28 @@ export function resolveWorkspaceDatabase(options = {}) {
   }
 
   return sqlite_db;
+}
+
+/**
+ * Find nearest `.beads/embeddeddolt` directory by walking up from start.
+ *
+ * @param {string} start
+ * @returns {string | null}
+ */
+export function findNearestEmbeddedDolt(start) {
+  let dir = path.resolve(start);
+  for (let i = 0; i < 100; i++) {
+    const embedded_dolt_path = path.join(dir, '.beads', 'embeddeddolt');
+    if (directoryExists(embedded_dolt_path)) {
+      return embedded_dolt_path;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return null;
 }
 
 /**
@@ -148,6 +183,17 @@ function fileExists(p) {
   try {
     fs.accessSync(p, fs.constants.F_OK);
     return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {string} p
+ */
+function directoryExists(p) {
+  try {
+    return fs.statSync(p).isDirectory();
   } catch {
     return false;
   }

--- a/server/db.test.js
+++ b/server/db.test.js
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
   findNearestBeadsDb,
   findNearestBeadsMetadata,
+  findNearestEmbeddedDolt,
   resolveDbPath,
   resolveWorkspaceDatabase
 } from './db.js';
@@ -113,7 +114,44 @@ describe('findNearestBeadsMetadata', () => {
   });
 });
 
+describe('findNearestEmbeddedDolt', () => {
+  test('finds nearest embeddeddolt directory walking up', () => {
+    const root = mkdtemp();
+    const nested = path.join(root, 'a', 'b', 'c');
+    fs.mkdirSync(nested, { recursive: true });
+    const embedded_dolt = path.join(root, '.beads', 'embeddeddolt');
+    fs.mkdirSync(embedded_dolt, { recursive: true });
+
+    const found = findNearestEmbeddedDolt(nested);
+
+    expect(found).toBe(embedded_dolt);
+  });
+
+  test('returns null when embeddeddolt is missing', () => {
+    const root = mkdtemp();
+
+    const found = findNearestEmbeddedDolt(root);
+
+    expect(found).toBeNull();
+  });
+});
+
 describe('resolveWorkspaceDatabase', () => {
+  test('uses embeddeddolt directory for embedded Dolt workspace', () => {
+    const root = mkdtemp();
+    const nested = path.join(root, 'workspace', 'nested');
+    fs.mkdirSync(nested, { recursive: true });
+    const beads_dir = path.join(root, '.beads');
+    fs.mkdirSync(path.join(beads_dir, 'embeddeddolt'), { recursive: true });
+    fs.writeFileSync(path.join(beads_dir, 'metadata.json'), '{}');
+
+    const found = resolveWorkspaceDatabase({ cwd: nested, env: {} });
+
+    expect(found.path).toBe(path.join(beads_dir, 'embeddeddolt'));
+    expect(found.source).toBe('embedded-dolt');
+    expect(found.exists).toBe(true);
+  });
+
   test('uses metadata directory for non-SQLite workspace', () => {
     const root = mkdtemp();
     const nested = path.join(root, 'workspace', 'nested');

--- a/server/watcher.js
+++ b/server/watcher.js
@@ -3,6 +3,15 @@ import path from 'node:path';
 import { resolveWorkspaceDatabase } from './db.js';
 import { debug } from './logging.js';
 
+const NOISY_DIRECTORY_ENTRIES = new Set([
+  '.lock',
+  'backup',
+  'export-state.json',
+  'interactions.jsonl',
+  'last-touched',
+  'push-state.json'
+]);
+
 /**
  * Watch the resolved workspace database target and invoke a callback after a
  * debounce window.
@@ -73,6 +82,12 @@ export function watchDb(root_dir, onChange, options = {}) {
         current_dir,
         { persistent: true },
         (event_type, filename) => {
+          if (filename && !current_file) {
+            const entry_name = String(filename);
+            if (NOISY_DIRECTORY_ENTRIES.has(entry_name)) {
+              return;
+            }
+          }
           if (current_file && filename && String(filename) !== current_file) {
             return;
           }

--- a/server/watcher.test.js
+++ b/server/watcher.test.js
@@ -3,6 +3,7 @@ import { watchDb } from './watcher.js';
 
 /** @type {{ dir: string, cb: (event: string, filename?: string) => void, w: { close: () => void } }[]} */
 const watchers = [];
+const directories = new Set();
 
 vi.mock('node:fs', () => {
   const watch = vi.fn((dir, _opts, cb) => {
@@ -16,11 +17,15 @@ vi.mock('node:fs', () => {
     watchers.push({ dir, cb, w });
     return /** @type {any} */ (w);
   });
-  return { default: { watch }, watch };
+  const statSync = vi.fn((file_path) => ({
+    isDirectory: () => directories.has(String(file_path))
+  }));
+  return { default: { watch, statSync }, watch, statSync };
 });
 
 beforeEach(() => {
   watchers.length = 0;
+  directories.clear();
   vi.useFakeTimers();
   vi.spyOn(console, 'warn').mockImplementation(() => {});
 });
@@ -114,6 +119,28 @@ describe('watchDb', () => {
     cb('change', 'ui.db');
     vi.advanceTimersByTime(10);
     expect(calls.length).toBe(2);
+
+    handle.close();
+  });
+
+  test('ignores housekeeping files for directory-backed workspaces', () => {
+    const calls = [];
+    directories.add('/repo/.beads/embeddeddolt');
+    const handle = watchDb('/repo', () => calls.push(null), {
+      debounce_ms: 10,
+      explicit_db: '/repo/.beads/embeddeddolt'
+    });
+    const { cb } = watchers[0];
+
+    cb('change', '.lock');
+    cb('change', 'last-touched');
+    cb('change', 'push-state.json');
+    vi.advanceTimersByTime(20);
+    expect(calls.length).toBe(0);
+
+    cb('change', 'bd');
+    vi.advanceTimersByTime(20);
+    expect(calls.length).toBe(1);
 
     handle.close();
   });


### PR DESCRIPTION
## Summary
- resolve embedded-Dolt workspaces to `.beads/embeddeddolt` instead of the parent `.beads` metadata directory
- ignore known housekeeping entries when watching directory-backed workspaces
- add regression coverage for embedded-Dolt resolution and watcher noise filtering

## Root cause
For embedded-Dolt workspaces, the server was falling back to the generic `.beads` metadata directory. That made the watcher observe housekeeping files like `last-touched`, `push-state.json`, and `export-state.json`, which are not the actual database. In a live backlog UI this created unnecessary refresh churn and made list subscriptions feel much slower and less predictable than they should.

## Why this is generally useful
This is generic `beads-ui` behavior, not a Sovereign-only deployment quirk. Any user running `bd` with embedded Dolt can hit the same watcher scope problem and get spurious refreshes from bookkeeping traffic in `.beads/`.

## Validation
- `npm run tsc`
- `npm test`
- `npm run lint`
- `npm run prettier:write`

## Perf evidence
In a live local deployment, list subscription snapshots dropped from multi-second / timeout behavior to sub-second responses after this fix, because watcher churn stopped retriggering refresh work against the same workspace.
