### PR TITLE
feat(app): hydrate list views from cached snapshots

### DIFF
--- a/app/data/snapshot-cache.js
+++ b/app/data/snapshot-cache.js
@@ -1,0 +1,76 @@
+import { subKeyOf } from './subscriptions-store.js';
+
+const CACHE_VERSION = 1;
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const STORAGE_PREFIX = 'beads-ui.snapshot.';
+
+/**
+ * Create a local snapshot cache for first-paint hydration.
+ *
+ * @param {Storage} storage
+ */
+export function createSnapshotCache(storage) {
+  /**
+   * @param {string} workspace_path
+   * @param {{ type: string, params?: Record<string, string|number|boolean> }} spec
+   */
+  function storageKey(workspace_path, spec) {
+    return `${STORAGE_PREFIX}${workspace_path}::${subKeyOf(spec)}`;
+  }
+
+  return {
+    /**
+     * @param {string | null | undefined} workspace_path
+     * @param {{ type: string, params?: Record<string, string|number|boolean> }} spec
+     * @returns {any[] | null}
+     */
+    read(workspace_path, spec) {
+      if (!workspace_path) {
+        return null;
+      }
+      try {
+        const raw = storage.getItem(storageKey(workspace_path, spec));
+        if (!raw) {
+          return null;
+        }
+        const parsed = JSON.parse(raw);
+        if (
+          !parsed ||
+          parsed.version !== CACHE_VERSION ||
+          !Array.isArray(parsed.items)
+        ) {
+          return null;
+        }
+        const captured_at = Number(parsed.captured_at) || 0;
+        if (captured_at > 0 && Date.now() - captured_at > CACHE_TTL_MS) {
+          return null;
+        }
+        return parsed.items;
+      } catch {
+        return null;
+      }
+    },
+    /**
+     * @param {string | null | undefined} workspace_path
+     * @param {{ type: string, params?: Record<string, string|number|boolean> }} spec
+     * @param {any[]} items
+     */
+    write(workspace_path, spec, items) {
+      if (!workspace_path || !Array.isArray(items) || items.length === 0) {
+        return;
+      }
+      try {
+        storage.setItem(
+          storageKey(workspace_path, spec),
+          JSON.stringify({
+            version: CACHE_VERSION,
+            captured_at: Date.now(),
+            items
+          })
+        );
+      } catch {
+        // Ignore quota / serialization errors.
+      }
+    }
+  };
+}

--- a/app/data/snapshot-cache.test.js
+++ b/app/data/snapshot-cache.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createSnapshotCache } from './snapshot-cache.js';
+
+describe('snapshot cache', () => {
+  test('reads back cached items for the same workspace and spec', () => {
+    const storage = /** @type {Storage} */ (window.localStorage);
+    const cache = createSnapshotCache(storage);
+    const spec = { type: 'all-issues' };
+    const items = [{ id: 'UI-1', title: 'One' }];
+
+    cache.write('/repo', spec, items);
+
+    expect(cache.read('/repo', spec)).toEqual(items);
+  });
+
+  test('returns null for stale cache entries', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-20T12:00:00Z'));
+    const storage = /** @type {Storage} */ (window.localStorage);
+    const cache = createSnapshotCache(storage);
+    const spec = { type: 'all-issues' };
+    cache.write('/repo', spec, [{ id: 'UI-1' }]);
+
+    vi.setSystemTime(new Date('2026-04-28T12:00:01Z'));
+
+    expect(cache.read('/repo', spec)).toBeNull();
+    vi.useRealTimers();
+  });
+});

--- a/app/data/subscription-issue-store.js
+++ b/app/data/subscription-issue-store.js
@@ -47,6 +47,31 @@ export function createSubscriptionIssueStore(id, options = {}) {
   }
 
   /**
+   * Seed the store from a cached snapshot without advancing revision state.
+   *
+   * @param {any[]} items
+   * @returns {boolean}
+   */
+  function hydrate(items) {
+    if (is_disposed || last_revision > 0 || items_by_id.size > 0) {
+      return false;
+    }
+    const next_items = Array.isArray(items) ? items : [];
+    if (next_items.length === 0) {
+      return false;
+    }
+    items_by_id.clear();
+    for (const it of next_items) {
+      if (it && typeof it.id === 'string' && it.id.length > 0) {
+        items_by_id.set(it.id, it);
+      }
+    }
+    rebuildOrdered();
+    emit();
+    return true;
+  }
+
+  /**
    * Apply snapshot/upsert/delete in revision order. Snapshots reset state.
    * - Ignore messages with revision <= last_revision (except snapshot which resets first).
    * - Preserve object identity when updating an existing item by mutating
@@ -139,6 +164,7 @@ export function createSubscriptionIssueStore(id, options = {}) {
         listeners.delete(fn);
       };
     },
+    hydrate,
     applyPush,
     snapshot() {
       // Return as read-only view; callers must not mutate

--- a/app/data/subscription-issue-store.test.js
+++ b/app/data/subscription-issue-store.test.js
@@ -63,7 +63,7 @@ describe('subscription issue store', () => {
     });
     const after = store.getById('X');
     expect(after?.title).toBe('X!');
-    expect(after).toBe(before); // identity preserved
+    expect(after).toBe(before);
   });
 
   test('ignores stale upsert by revision and timestamp', () => {
@@ -82,7 +82,6 @@ describe('subscription issue store', () => {
         }
       ]
     });
-    // stale revision
     store.applyPush({
       type: 'upsert',
       id: 's1',
@@ -96,7 +95,6 @@ describe('subscription issue store', () => {
       }
     });
     expect(store.getById('X')?.title).toBe('x');
-    // equal revision is ignored
     store.applyPush({
       type: 'upsert',
       id: 's1',
@@ -110,7 +108,6 @@ describe('subscription issue store', () => {
       }
     });
     expect(store.getById('X')?.title).toBe('x');
-    // higher revision but stale timestamp is ignored
     store.applyPush({
       type: 'upsert',
       id: 's1',
@@ -190,5 +187,23 @@ describe('subscription issue store', () => {
     });
     expect(hit).toBe(0);
     expect(store.size()).toBe(0);
+  });
+
+  test('hydrates from cached items without blocking later live snapshots', () => {
+    const store = createSubscriptionIssueStore('tab:issues');
+
+    const hydrated = store.hydrate([{ id: 'UI-1', title: 'cached' }]);
+
+    expect(hydrated).toBe(true);
+    expect(store.snapshot().map((it) => it.id)).toEqual(['UI-1']);
+
+    store.applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: [{ id: 'UI-2', title: 'live' }]
+    });
+
+    expect(store.snapshot().map((it) => it.id)).toEqual(['UI-2']);
   });
 });

--- a/app/main.js
+++ b/app/main.js
@@ -4,6 +4,7 @@
 import { html, render } from 'lit-html';
 import { createListSelectors } from './data/list-selectors.js';
 import { createDataLayer } from './data/providers.js';
+import { createSnapshotCache } from './data/snapshot-cache.js';
 import { createSubscriptionIssueStores } from './data/subscription-issue-stores.js';
 import { createSubscriptionStore } from './data/subscriptions-store.js';
 import { createHashRouter, parseHash, parseView } from './router.js';
@@ -109,6 +110,86 @@ export function bootstrap(root_element) {
     const subscriptions = createSubscriptionStore(tracked_send);
     // Per-subscription stores (source of truth)
     const sub_issue_stores = createSubscriptionIssueStores();
+    const snapshot_cache = createSnapshotCache(window.localStorage);
+    /** @type {Map<string, { type: string, params?: Record<string, string|number|boolean> }>} */
+    const cached_specs = new Map();
+    /** @type {ReturnType<typeof setTimeout> | null} */
+    let persist_snapshot_timer = null;
+
+    /**
+     * @returns {string | null}
+     */
+    function getSnapshotWorkspacePath() {
+      const current = store.getState().workspace.current?.path;
+      if (current) {
+        return current;
+      }
+      const saved = window.localStorage.getItem('beads-ui.workspace');
+      return saved && saved.length > 0 ? saved : null;
+    }
+
+    /**
+     * @param {string} client_id
+     * @param {{ type: string, params?: Record<string, string|number|boolean> }} spec
+     */
+    function hydrateStoreFromCache(client_id, spec) {
+      const store_for_id = sub_issue_stores.getStore(client_id);
+      if (!store_for_id || typeof store_for_id.hydrate !== 'function') {
+        return;
+      }
+      const cached_items = snapshot_cache.read(
+        getSnapshotWorkspacePath(),
+        spec
+      );
+      if (cached_items && cached_items.length > 0) {
+        store_for_id.hydrate(cached_items);
+      }
+    }
+
+    /**
+     * @param {string} client_id
+     * @param {{ type: string, params?: Record<string, string|number|boolean> }} spec
+     */
+    function registerCachedStore(client_id, spec) {
+      sub_issue_stores.register(client_id, spec);
+      cached_specs.set(client_id, spec);
+      hydrateStoreFromCache(client_id, spec);
+    }
+
+    /**
+     * @param {string} client_id
+     */
+    function unregisterCachedStore(client_id) {
+      cached_specs.delete(client_id);
+      sub_issue_stores.unregister(client_id);
+    }
+
+    function persistCachedSnapshots() {
+      const workspace_path = getSnapshotWorkspacePath();
+      if (!workspace_path) {
+        return;
+      }
+      for (const [client_id, spec] of cached_specs.entries()) {
+        const items = sub_issue_stores.snapshotFor(client_id);
+        if (items.length > 0) {
+          snapshot_cache.write(workspace_path, spec, items);
+        }
+      }
+    }
+
+    function schedulePersistCachedSnapshots() {
+      if (persist_snapshot_timer) {
+        clearTimeout(persist_snapshot_timer);
+      }
+      persist_snapshot_timer = setTimeout(() => {
+        persist_snapshot_timer = null;
+        persistCachedSnapshots();
+      }, 50);
+    }
+
+    sub_issue_stores.subscribe(() => {
+      schedulePersistCachedSnapshots();
+    });
     // Route per-subscription push envelopes to the owning store
     client.on('snapshot', (payload) => {
       const p = /** @type {any} */ (payload);
@@ -192,7 +273,7 @@ export function bootstrap(root_element) {
       ];
       for (const id of storeIds) {
         try {
-          sub_issue_stores.unregister(id);
+          unregisterCachedStore(id);
         } catch {
           // ignore
         }
@@ -286,6 +367,9 @@ export function bootstrap(root_element) {
               }
             : null;
           store.setState({ workspace: { current, available } });
+          if (current?.path) {
+            window.localStorage.setItem('beads-ui.workspace', current.path);
+          }
 
           // Check if we have a saved preference that differs from current
           const savedWorkspace =
@@ -706,7 +790,7 @@ export function bootstrap(root_element) {
         const key = JSON.stringify(spec);
         // Register store first to capture the initial snapshot
         try {
-          sub_issue_stores.register('tab:issues', spec);
+          registerCachedStore('tab:issues', spec);
         } catch (err) {
           log('register issues store failed: %o', err);
         }
@@ -736,7 +820,7 @@ export function bootstrap(root_element) {
         unsub_issues_tab = null;
         last_issues_spec_key = null;
         try {
-          sub_issue_stores.unregister('tab:issues');
+          unregisterCachedStore('tab:issues');
         } catch (err) {
           log('unregister issues store failed: %o', err);
         }
@@ -746,7 +830,7 @@ export function bootstrap(root_element) {
       if (s.view === 'epics') {
         // Register store first to avoid race with initial snapshot
         try {
-          sub_issue_stores.register('tab:epics', { type: 'epics' });
+          registerCachedStore('tab:epics', { type: 'epics' });
         } catch (err) {
           log('register epics store failed: %o', err);
         }
@@ -770,7 +854,7 @@ export function bootstrap(root_element) {
         void unsub_epics_tab().catch(() => {});
         unsub_epics_tab = null;
         try {
-          sub_issue_stores.unregister('tab:epics');
+          unregisterCachedStore('tab:epics');
         } catch (err) {
           log('unregister epics store failed: %o', err);
         }
@@ -784,7 +868,7 @@ export function bootstrap(root_element) {
           !pending_subscriptions.has('tab:board:ready')
         ) {
           try {
-            sub_issue_stores.register('tab:board:ready', {
+            registerCachedStore('tab:board:ready', {
               type: 'ready-issues'
             });
           } catch (err) {
@@ -808,7 +892,7 @@ export function bootstrap(root_element) {
           !pending_subscriptions.has('tab:board:in-progress')
         ) {
           try {
-            sub_issue_stores.register('tab:board:in-progress', {
+            registerCachedStore('tab:board:in-progress', {
               type: 'in-progress-issues'
             });
           } catch (err) {
@@ -834,7 +918,7 @@ export function bootstrap(root_element) {
           !pending_subscriptions.has('tab:board:closed')
         ) {
           try {
-            sub_issue_stores.register('tab:board:closed', {
+            registerCachedStore('tab:board:closed', {
               type: 'closed-issues'
             });
           } catch (err) {
@@ -858,7 +942,7 @@ export function bootstrap(root_element) {
           !pending_subscriptions.has('tab:board:blocked')
         ) {
           try {
-            sub_issue_stores.register('tab:board:blocked', {
+            registerCachedStore('tab:board:blocked', {
               type: 'blocked-issues'
             });
           } catch (err) {
@@ -882,7 +966,7 @@ export function bootstrap(root_element) {
           void unsub_board_ready().catch(() => {});
           unsub_board_ready = null;
           try {
-            sub_issue_stores.unregister('tab:board:ready');
+            unregisterCachedStore('tab:board:ready');
           } catch (err) {
             log('unregister board:ready failed: %o', err);
           }
@@ -891,7 +975,7 @@ export function bootstrap(root_element) {
           void unsub_board_in_progress().catch(() => {});
           unsub_board_in_progress = null;
           try {
-            sub_issue_stores.unregister('tab:board:in-progress');
+            unregisterCachedStore('tab:board:in-progress');
           } catch (err) {
             log('unregister board:in-progress failed: %o', err);
           }
@@ -900,7 +984,7 @@ export function bootstrap(root_element) {
           void unsub_board_closed().catch(() => {});
           unsub_board_closed = null;
           try {
-            sub_issue_stores.unregister('tab:board:closed');
+            unregisterCachedStore('tab:board:closed');
           } catch (err) {
             log('unregister board:closed failed: %o', err);
           }
@@ -909,7 +993,7 @@ export function bootstrap(root_element) {
           void unsub_board_blocked().catch(() => {});
           unsub_board_blocked = null;
           try {
-            sub_issue_stores.unregister('tab:board:blocked');
+            unregisterCachedStore('tab:board:blocked');
           } catch (err) {
             log('unregister board:blocked failed: %o', err);
           }

--- a/app/main.snapshot-cache.test.js
+++ b/app/main.snapshot-cache.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createSnapshotCache } from './data/snapshot-cache.js';
+import { bootstrap } from './main.js';
+import { createWsClient } from './ws.js';
+
+/** @type {{ type: string, payload: any }[]} */
+const calls = [];
+
+vi.mock('./ws.js', () => {
+  /** @type {Record<string, (p:any)=>void>} */
+  const handlers = {};
+  const singleton = {
+    /**
+     * @param {string} type
+     * @param {any} payload
+     */
+    async send(type, payload) {
+      calls.push({ type, payload });
+      return null;
+    },
+    /**
+     * @param {string} type
+     * @param {(p:any)=>void} handler
+     */
+    on(type, handler) {
+      handlers[type] = handler;
+      return () => {};
+    },
+    close() {},
+    getState() {
+      return 'open';
+    }
+  };
+  return { createWsClient: () => singleton };
+});
+
+describe('main snapshot cache hydration', () => {
+  test('renders cached issues before the live snapshot arrives', async () => {
+    const cache = createSnapshotCache(window.localStorage);
+    window.localStorage.setItem('beads-ui.workspace', '/repo');
+    cache.write('/repo', { type: 'all-issues' }, [
+      { id: 'UI-1', title: 'Cached One', status: 'open', priority: 1 }
+    ]);
+
+    document.body.innerHTML = '<main id="app"></main>';
+    const root = /** @type {HTMLElement} */ (document.getElementById('app'));
+
+    bootstrap(root);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const rows = Array.from(
+      document.querySelectorAll('#list-root tr.issue-row')
+    ).map((row) => row.querySelector('td')?.textContent?.trim());
+
+    expect(rows).toContain('UI-1');
+    expect(calls.some((call) => call.type === 'subscribe-list')).toBe(true);
+    void createWsClient();
+  });
+});

--- a/types/subscription-issue-store.ts
+++ b/types/subscription-issue-store.ts
@@ -35,6 +35,13 @@ export interface SubscriptionIssueStore {
    */
   applyPush(msg: SnapshotMsg | UpsertMsg | DeleteMsg): void;
 
+  /**
+   * Seed the store with a cached snapshot for first paint. Hydration must not
+   * advance server revision state; a later live snapshot should still replace
+   * the cached data deterministically.
+   */
+  hydrate(issues: Issue[]): boolean;
+
   /** Stable, read-only snapshot of issues for rendering. */
   snapshot(): readonly Issue[];
 


### PR DESCRIPTION
## Summary
- hydrate issue, epic, and board list stores from a workspace-scoped local snapshot cache
- replace cached data deterministically when the live websocket snapshot arrives
- add tests around cache persistence, store hydration, and initial app bootstrap behavior

## Validation
- npm run tsc
- npm test
- npm run lint
- npm run prettier:write