### PR TITLE
fix(app): preserve detail comments across live refreshes

### DIFF
--- a/app/views/detail.js
+++ b/app/views/detail.js
@@ -114,6 +114,10 @@ export function createDetailView(
   let comment_text = '';
   /** @type {boolean} */
   let comment_pending = false;
+  /** @type {boolean} */
+  let comments_loading = false;
+  /** @type {Comment[] | null} */
+  let comments_override = null;
 
   /** @type {HTMLDialogElement | null} */
   let delete_dialog = null;
@@ -230,6 +234,37 @@ export function createDetailView(
     );
   }
 
+  async function refreshComments(force = false) {
+    if (!current_id || !current) {
+      return;
+    }
+    if (!force && Array.isArray(/** @type {any} */ (current).comments)) {
+      return;
+    }
+    if (comments_loading) {
+      return;
+    }
+    comments_loading = true;
+    const target_id = current_id;
+    try {
+      const comments = await sendFn('get-comments', { id: target_id });
+      if (
+        Array.isArray(comments) &&
+        current &&
+        current_id === target_id &&
+        String(current.id) === String(target_id)
+      ) {
+        /** @type {any} */ (current).comments = comments;
+        comments_override = null;
+        doRender();
+      }
+    } catch (err) {
+      log('fetch comments failed %s %o', target_id, err);
+    } finally {
+      comments_loading = false;
+    }
+  }
+
   /**
    * Refresh current from subscription store snapshot if available.
    */
@@ -245,10 +280,28 @@ export function createDetailView(
       issue_stores.snapshotFor(`detail:${current_id}`)
     );
     if (Array.isArray(arr) && arr.length > 0) {
+      const previous = current;
       // First item is the issue for this subscription
       const found =
         arr.find((it) => String(it.id) === String(current_id)) || arr[0];
-      current = /** @type {IssueDetail} */ (found);
+      const next = /** @type {IssueDetail & { comments?: Comment[] }} */ (
+        found
+      );
+      let preserved_comments = false;
+      const previous_comments =
+        previous && Array.isArray(/** @type {any} */ (previous).comments)
+          ? /** @type {Comment[]} */ (/** @type {any} */ (previous).comments)
+          : comments_override;
+      if (!Array.isArray(next.comments) && Array.isArray(previous_comments)) {
+        comments_override = previous_comments;
+        preserved_comments = true;
+      } else if (Array.isArray(next.comments)) {
+        comments_override = null;
+      }
+      current = next;
+      if (preserved_comments) {
+        void refreshComments(true);
+      }
     }
   }
 
@@ -839,6 +892,7 @@ export function createDetailView(
       if (Array.isArray(result)) {
         // Update comments in current issue
         /** @type {any} */ (current).comments = result;
+        comments_override = null;
         comment_text = '';
         doRender();
       }
@@ -1170,7 +1224,9 @@ export function createDetailView(
     // Comments section
     const comments = Array.isArray(/** @type {any} */ (issue).comments)
       ? /** @type {Comment[]} */ (/** @type {any} */ (issue).comments)
-      : [];
+      : Array.isArray(comments_override)
+        ? comments_override
+        : [];
     const comments_block = html`<div class="comments">
       <div class="props-card__title">Comments</div>
       ${comments.length === 0
@@ -1500,19 +1556,13 @@ export function createDetailView(
       pending = false;
       comment_text = '';
       comment_pending = false;
+      comments_loading = false;
+      comments_override = null;
       doRender();
 
       // Fetch comments if not already present
       if (current && !(/** @type {any} */ (current).comments)) {
-        try {
-          const comments = await sendFn('get-comments', { id: current_id });
-          if (Array.isArray(comments) && current && current_id === id) {
-            /** @type {any} */ (current).comments = comments;
-            doRender();
-          }
-        } catch (err) {
-          log('fetch comments failed %s %o', id, err);
-        }
+        void refreshComments();
       }
     },
     clear() {

--- a/app/views/detail.test.js
+++ b/app/views/detail.test.js
@@ -416,6 +416,127 @@ describe('views/detail', () => {
     expect(commentItems[0].textContent).toContain('Fetched');
   });
 
+  test('skips comments fetch when detail snapshot already includes comments', async () => {
+    document.body.innerHTML =
+      '<section class="panel"><div id="mount"></div></section>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+
+    const issue = {
+      id: 'UI-102A',
+      title: 'Snapshot already has comments',
+      dependencies: [],
+      dependents: [],
+      comments: [
+        {
+          id: 1,
+          author: 'Snapshot',
+          text: 'Snapshot comment',
+          created_at: '2025-01-15T12:00:00Z'
+        }
+      ]
+    };
+
+    /** @type {Array<{type: string, payload: unknown}>} */
+    const calls = [];
+    const sendFn = async (
+      /** @type {string} */ type,
+      /** @type {unknown} */ payload
+    ) => {
+      calls.push({ type, payload });
+      return {};
+    };
+
+    const stores = {
+      snapshotFor(/** @type {string} */ id) {
+        return id === 'detail:UI-102A' ? [issue] : [];
+      },
+      subscribe() {
+        return () => {};
+      }
+    };
+
+    const view = createDetailView(mount, sendFn, undefined, stores);
+    await view.load('UI-102A');
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(calls).toHaveLength(0);
+    const commentItems = mount.querySelectorAll('.comment-item');
+    expect(commentItems.length).toBe(1);
+    expect(commentItems[0].textContent).toContain('Snapshot comment');
+  });
+
+  test('preserves fetched comments when a live detail refresh omits them', async () => {
+    document.body.innerHTML =
+      '<section class="panel"><div id="mount"></div></section>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+
+    /** @type {Array<Record<string, unknown>>} */
+    const snapshot = [
+      {
+        id: 'UI-103',
+        title: 'Comment refresh regression',
+        dependencies: [],
+        dependents: []
+      }
+    ];
+
+    /** @type {Array<{ type: string, payload: unknown }>} */
+    const calls = [];
+
+    /** @type {null | (() => void)} */
+    let emit = null;
+    const sendFn = async (
+      /** @type {string} */ type,
+      /** @type {unknown} */ payload
+    ) => {
+      calls.push({ type, payload });
+      if (type === 'get-comments') {
+        return [
+          {
+            id: 1,
+            author: 'Fetched',
+            text: 'Fetched comment',
+            created_at: '2025-01-15T12:00:00Z'
+          }
+        ];
+      }
+      return {};
+    };
+
+    const stores = {
+      snapshotFor(/** @type {string} */ id) {
+        return id === 'detail:UI-103' ? snapshot : [];
+      },
+      subscribe(/** @type {() => void} */ fn) {
+        emit = fn;
+        return () => {};
+      }
+    };
+
+    const view = createDetailView(mount, sendFn, undefined, stores);
+    await view.load('UI-103');
+    await new Promise((r) => setTimeout(r, 50));
+
+    snapshot[0] = {
+      id: 'UI-103',
+      title: 'Comment refresh regression',
+      updated_at: '2025-01-16T12:00:00Z',
+      dependencies: [],
+      dependents: []
+    };
+
+    const notify = emit;
+    if (notify) {
+      /** @type {() => void} */ (notify)();
+    }
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(calls.filter((c) => c.type === 'get-comments')).toHaveLength(2);
+    const commentItems = mount.querySelectorAll('.comment-item');
+    expect(commentItems.length).toBe(1);
+    expect(commentItems[0].textContent).toContain('Fetched comment');
+  });
+
   test('renders close reason when present on closed issue', async () => {
     document.body.innerHTML =
       '<section class="panel"><div id="mount"></div></section>';

--- a/server/list-adapters.js
+++ b/server/list-adapters.js
@@ -151,6 +151,32 @@ export async function fetchListForSubscription(spec, options = {}) {
         ? [res.stdoutJson]
         : [];
 
+    if (String(spec.type) === 'issue-detail') {
+      const detail_id = String(spec.params?.id || '').trim();
+      if (detail_id.length > 0 && raw.length > 0) {
+        try {
+          const comments = await runBdJson(['comments', detail_id, '--json'], {
+            cwd: options.cwd
+          });
+          if (
+            comments?.code === 0 &&
+            Array.isArray(comments.stdoutJson) &&
+            raw[0] &&
+            typeof raw[0] === 'object'
+          ) {
+            raw = [
+              {
+                ...raw[0],
+                comments: comments.stdoutJson
+              }
+            ];
+          }
+        } catch (err) {
+          log('comments lookup failed for %s: %o', detail_id, err);
+        }
+      }
+    }
+
     // Special-case mapping for `epics`: current bd output nests the epic under
     // an `epic` key and exposes counters at the top level. Flatten so that
     // each entry has a top-level `id` and core fields expected by the registry.

--- a/server/list-adapters.test.js
+++ b/server/list-adapters.test.js
@@ -106,6 +106,93 @@ describe('list adapters for subscription types', () => {
     }
   });
 
+  test('fetchListForSubscription enriches issue-detail with comments', async () => {
+    /** @type {import('vitest').Mock} */ (runBdJson)
+      .mockResolvedValueOnce({
+        code: 0,
+        stdoutJson: {
+          id: 'UI-123',
+          title: 'Detail issue',
+          updated_at: '2024-01-01T00:00:00.000Z',
+          closed_at: null
+        }
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdoutJson: [
+          {
+            id: 1,
+            author: 'alice',
+            text: 'Existing comment',
+            created_at: '2024-01-01T00:00:00.000Z'
+          }
+        ]
+      });
+
+    const res = await fetchListForSubscription({
+      type: 'issue-detail',
+      params: { id: 'UI-123' }
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.items).toHaveLength(1);
+      expect(res.items[0]).toMatchObject({
+        id: 'UI-123',
+        comments: [
+          {
+            id: 1,
+            author: 'alice',
+            text: 'Existing comment'
+          }
+        ]
+      });
+    }
+
+    expect(runBdJson).toHaveBeenNthCalledWith(
+      1,
+      ['show', 'UI-123', '--json'],
+      {}
+    );
+    expect(runBdJson).toHaveBeenNthCalledWith(
+      2,
+      ['comments', 'UI-123', '--json'],
+      {}
+    );
+  });
+
+  test('fetchListForSubscription keeps issue-detail when comments lookup fails', async () => {
+    /** @type {import('vitest').Mock} */ (runBdJson)
+      .mockResolvedValueOnce({
+        code: 0,
+        stdoutJson: {
+          id: 'UI-124',
+          title: 'Detail issue',
+          updated_at: '2024-01-01T00:00:00.000Z',
+          closed_at: null
+        }
+      })
+      .mockResolvedValueOnce({
+        code: 1,
+        stderr: 'comments unavailable'
+      });
+
+    const res = await fetchListForSubscription({
+      type: 'issue-detail',
+      params: { id: 'UI-124' }
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.items).toHaveLength(1);
+      expect(res.items[0]).toMatchObject({
+        id: 'UI-124',
+        title: 'Detail issue'
+      });
+      expect('comments' in res.items[0]).toBe(false);
+    }
+  });
+
   test('filters tombstoned epics', async () => {
     /** @type {import('vitest').Mock} */ (runBdJson).mockResolvedValue({
       code: 0,

--- a/server/ws.comments.test.js
+++ b/server/ws.comments.test.js
@@ -113,7 +113,7 @@ describe('add-comment handler', () => {
     vi.clearAllMocks();
   });
 
-  test('adds comment with git author and returns updated comments', async () => {
+  test('adds comment with git actor and returns updated comments', async () => {
     const gitUser = /** @type {import('vitest').Mock} */ (getGitUserName);
     const rb = /** @type {import('vitest').Mock} */ (runBd);
     const rj = /** @type {import('vitest').Mock} */ (runBdJson);
@@ -151,12 +151,12 @@ describe('add-comment handler', () => {
     expect(reply.ok).toBe(true);
     expect(reply.payload).toEqual(updatedComments);
 
-    // Verify bd was called with correct args including --author
+    // Verify bd was called with correct args including --actor
     expect(rb).toHaveBeenCalledWith([
       'comment',
       'UI-1',
       'New comment',
-      '--author',
+      '--actor',
       'Test User'
     ]);
   });

--- a/server/ws.js
+++ b/server/ws.js
@@ -1197,11 +1197,11 @@ export async function handleMessage(ws, data) {
       return;
     }
 
-    // Get git user name for author attribution
+    // Get git user name for actor attribution
     const author = await getGitUserName();
     const args = ['comment', id, text.trim()];
     if (author) {
-      args.push('--author', author);
+      args.push('--actor', author);
     }
 
     const res = await runBd(args);


### PR DESCRIPTION
## Summary
- enrich issue-detail subscription snapshots with comments when available
- preserve visible comments through live detail refreshes that omit the field and refetch to converge
- add regression coverage for omitted-comment refreshes, existing enriched snapshots, and comments lookup fallback

## Validation
- npm run tsc
- npm test
- npm run lint
- npm run prettier:write