### PR TITLE
Watch Dolt-backed Beads JSONL changes

### DIFF
--- a/server/watcher.js
+++ b/server/watcher.js
@@ -17,8 +17,8 @@ import { debug } from './logging.js';
  * @returns {{ close: () => void, rebind: (opts?: { root_dir?: string, explicit_db?: string }) => void, path: string }}
  */
 export function watchDb(root_dir, onChange, options = {}) {
-  const debounce_ms = options.debounce_ms ?? 250;
-  const cooldown_ms = options.cooldown_ms ?? 1000;
+  const debounce_ms = options.debounce_ms ?? 750;
+  const cooldown_ms = options.cooldown_ms ?? 4000;
   const log = debug('watcher');
 
   /** @type {ReturnType<typeof setTimeout> | undefined} */
@@ -37,10 +37,12 @@ export function watchDb(root_dir, onChange, options = {}) {
     if (timer) {
       clearTimeout(timer);
     }
+    const now = Date.now();
+    const wait_ms = Math.max(debounce_ms, cooldown_until - now);
     timer = setTimeout(() => {
       onChange();
       cooldown_until = Date.now() + cooldown_ms;
-    }, debounce_ms);
+    }, wait_ms);
     timer.unref();
   };
 
@@ -73,13 +75,16 @@ export function watchDb(root_dir, onChange, options = {}) {
         current_dir,
         { persistent: true },
         (event_type, filename) => {
-          if (current_file && filename && String(filename) !== current_file) {
-            return;
-          }
-          if (event_type === 'change' || event_type === 'rename') {
-            if (Date.now() < cooldown_until) {
+          const signal_files = new Set(['issues.jsonl', 'interactions.jsonl']);
+          if (filename) {
+            const name = String(filename);
+            const matches_db_basename = current_file && name === current_file;
+            const is_signal_file = signal_files.has(name);
+            if (!matches_db_basename && !is_signal_file) {
               return;
             }
+          }
+          if (event_type === 'change' || event_type === 'rename') {
             log('fs %s %s', event_type, filename || '');
             schedule();
           }
@@ -119,6 +124,10 @@ export function watchDb(root_dir, onChange, options = {}) {
       const next_path = next_resolved.path;
       if (next_path !== current_path) {
         // swap watcher
+        if (timer) {
+          clearTimeout(timer);
+          timer = undefined;
+        }
         watcher?.close();
         cooldown_until = 0;
         bind(next_root, next_explicit);

--- a/server/watcher.test.js
+++ b/server/watcher.test.js
@@ -55,12 +55,37 @@ describe('watchDb', () => {
     const calls = [];
     const handle = watchDb('/repo', () => calls.push(null), {
       debounce_ms: 50,
+      cooldown_ms: 100,
       explicit_db: '/repo/.beads/ui.db'
     });
     const { cb } = watchers[0];
     cb('change', 'something-else.db');
     vi.advanceTimersByTime(60);
     expect(calls.length).toBe(0);
+    handle.close();
+  });
+
+  test('accepts Dolt JSONL mutation signal files', () => {
+    const calls = [];
+    const handle = watchDb('/repo', () => calls.push(null), {
+      debounce_ms: 50,
+      cooldown_ms: 100,
+      explicit_db: '/repo/.beads/ui.db'
+    });
+    const { cb } = watchers[0];
+
+    cb('change', 'issues.jsonl');
+    vi.advanceTimersByTime(50);
+    expect(calls.length).toBe(1);
+
+    cb('change', 'interactions.jsonl');
+    vi.advanceTimersByTime(101);
+    expect(calls.length).toBe(2);
+
+    cb('change', 'last-touched');
+    vi.advanceTimersByTime(101);
+    expect(calls.length).toBe(2);
+
     handle.close();
   });
 
@@ -93,7 +118,28 @@ describe('watchDb', () => {
     handle.close();
   });
 
-  test('ignores changes during cooldown window', () => {
+  test('rebind clears pending cooldown refresh', () => {
+    const calls = [];
+    const handle = watchDb('/repo', () => calls.push(null), {
+      debounce_ms: 10,
+      cooldown_ms: 100,
+      explicit_db: '/repo/.beads/ui.db'
+    });
+    const first = watchers[0];
+
+    first.cb('change', 'ui.db');
+    vi.advanceTimersByTime(10);
+    expect(calls.length).toBe(1);
+
+    first.cb('change', 'ui.db');
+    handle.rebind({ explicit_db: '/other/.beads/alt.db' });
+    vi.advanceTimersByTime(100);
+    expect(calls.length).toBe(1);
+
+    handle.close();
+  });
+
+  test('delays changes during cooldown window', () => {
     const calls = [];
     const handle = watchDb('/repo', () => calls.push(null), {
       debounce_ms: 10,
@@ -110,9 +156,7 @@ describe('watchDb', () => {
     vi.advanceTimersByTime(10);
     expect(calls.length).toBe(1);
 
-    vi.advanceTimersByTime(100);
-    cb('change', 'ui.db');
-    vi.advanceTimersByTime(10);
+    vi.advanceTimersByTime(90);
     expect(calls.length).toBe(2);
 
     handle.close();


### PR DESCRIPTION
## Summary
- Accept Beads JSONL mutation files (`issues.jsonl`, `interactions.jsonl`) as watcher signals so Dolt-backed workspaces refresh without manual reloads.
- Use a larger default debounce/cooldown window and schedule one trailing refresh after cooldown instead of dropping changes.
- Clear pending trailing refreshes on workspace rebind.

## Validation
- `PATH=/Users/edward/.local/share/nvm/v22.13.1/bin:$PATH npm test -- server/watcher.test.js`
- `PATH=/Users/edward/.local/share/nvm/v22.13.1/bin:$PATH npm run lint -- server/watcher.js server/watcher.test.js`
- `PATH=/Users/edward/.local/share/nvm/v22.13.1/bin:$PATH npm run tsc`
- `PATH=/Users/edward/.local/share/nvm/v22.13.1/bin:$PATH npm run prettier:check -- server/watcher.js server/watcher.test.js`