### PR TITLE
fix(ws): pin bd invocations to the active workspace cwd (#87)

### DIFF
--- a/server/bd.js
+++ b/server/bd.js
@@ -146,6 +146,17 @@ function runBdUnlocked(args, options = {}) {
       finish(127);
     });
     child.on('close', (code) => {
+      const exit_code = Number(code || 0);
+      if (exit_code !== 0) {
+        // Mirror the logging runBdJson already does so non-JSON callers
+        // (mutation handlers) leave a debug trace on failure.
+        log(
+          'bd exited with code %d (args=%o) stderr=%s',
+          exit_code,
+          final_args,
+          err_chunks.join('')
+        );
+      }
       finish(code);
     });
   });
@@ -207,12 +218,7 @@ async function withBdRunQueue(operation) {
 export async function runBdJson(args, options = {}) {
   const result = await runBd(args, options);
   if (result.code !== 0) {
-    log(
-      'bd exited with code %d (args=%o) stderr=%s',
-      result.code,
-      args,
-      result.stderr
-    );
+    // Non-zero exits are logged centrally in runBdUnlocked's child.on('close').
     return { code: result.code, stderr: result.stderr };
   }
   /** @type {unknown} */

--- a/server/bd.test.js
+++ b/server/bd.test.js
@@ -153,6 +153,43 @@ describe('runBd', () => {
     const options = mockedSpawn.mock.calls[0][2];
     expect(options.env.BEADS_DB).toBe('/custom/workspace.db');
   });
+
+  test('logs non-zero exit with args and stderr (parity with runBdJson)', async () => {
+    // Enable the bd debug namespace and capture stderr writes so we can
+    // assert the new exit log fires. Without this log, write failures from
+    // mutation handlers (which use runBd, not runBdJson) leave no trace.
+    const debug_mod = await import('debug');
+    const prev_enabled = process.env.DEBUG;
+    debug_mod.default.enable('beads-ui:bd');
+
+    /** @type {string[]} */
+    const captured = [];
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(
+      /** @param {any} chunk */ (chunk) => {
+        captured.push(String(chunk));
+        return true;
+      }
+    );
+
+    try {
+      mockedSpawn.mockReturnValueOnce(makeFakeProc('', 'boom', 2));
+      const res = await runBd(['update', 'UI-7', '--status', 'in_progress']);
+      expect(res.code).toBe(2);
+
+      const joined = captured.join('');
+      expect(joined).toMatch(/beads-ui:bd/);
+      expect(joined).toMatch(/code 2/);
+      expect(joined).toMatch(/update/);
+      expect(joined).toMatch(/boom/);
+    } finally {
+      spy.mockRestore();
+      if (prev_enabled === undefined) {
+        debug_mod.default.disable();
+      } else {
+        debug_mod.default.enable(prev_enabled);
+      }
+    }
+  });
 });
 
 describe('runBdJson', () => {

--- a/server/ws.comments.test.js
+++ b/server/ws.comments.test.js
@@ -63,7 +63,10 @@ describe('get-comments handler', () => {
     expect(reply.payload).toEqual(comments);
 
     // Verify bd was called with correct args
-    expect(rj).toHaveBeenCalledWith(['comments', 'UI-1', '--json']);
+    expect(rj).toHaveBeenCalledWith(
+      ['comments', 'UI-1', '--json'],
+      expect.objectContaining({})
+    );
   });
 
   test('returns error when issue id missing', async () => {
@@ -152,14 +155,10 @@ describe('add-comment handler', () => {
     expect(reply.payload).toEqual(updatedComments);
 
     // Verify bd was called with correct args including --author
-    expect(rb).toHaveBeenCalledWith([
-      'comments',
-      'add',
-      'UI-1',
-      'New comment',
-      '--author',
-      'Test User'
-    ]);
+    expect(rb).toHaveBeenCalledWith(
+      ['comments', 'add', 'UI-1', 'New comment', '--author', 'Test User'],
+      expect.objectContaining({})
+    );
   });
 
   test('adds comment without author when git user name is empty', async () => {
@@ -191,12 +190,10 @@ describe('add-comment handler', () => {
     expect(reply.ok).toBe(true);
 
     // Verify bd was called without --author
-    expect(rb).toHaveBeenCalledWith([
-      'comments',
-      'add',
-      'UI-1',
-      'Anonymous comment'
-    ]);
+    expect(rb).toHaveBeenCalledWith(
+      ['comments', 'add', 'UI-1', 'Anonymous comment'],
+      expect.objectContaining({})
+    );
   });
 
   test('returns error when text is empty', async () => {

--- a/server/ws.delete.test.js
+++ b/server/ws.delete.test.js
@@ -42,7 +42,10 @@ describe('delete-issue handler', () => {
     );
 
     // Check bd delete was called with --force
-    expect(rb).toHaveBeenCalledWith(['delete', 'beads-abc123', '--force']);
+    expect(rb).toHaveBeenCalledWith(
+      ['delete', 'beads-abc123', '--force'],
+      expect.objectContaining({})
+    );
 
     // Check response
     expect(ws.sent.length).toBe(1);

--- a/server/ws.js
+++ b/server/ws.js
@@ -597,6 +597,12 @@ export async function handleMessage(ws, data) {
 
   const req = json;
 
+  // Pin every bd invocation made during this message to the active workspace.
+  // Without this, runBd/runBdJson fall back to process.cwd() and bd reports
+  // "no beads database found" for any workspace selected via set-workspace.
+  // See mantoni/beads-ui#87.
+  const bd_options = { cwd: CURRENT_WORKSPACE?.root_dir };
+
   // Dispatch known types here as we implement them. For now, only a ping utility.
   if (req.type === /** @type {MessageType} */ ('ping')) {
     ws.send(JSON.stringify(makeOk(req, { ts: Date.now() })));
@@ -749,14 +755,14 @@ export async function handleMessage(ws, data) {
       return;
     }
     // Pass empty string to clear assignee when requested
-    const res = await runBd(['update', id, '--assignee', assignee]);
+    const res = await runBd(['update', id, '--assignee', assignee], bd_options);
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
       );
       return;
     }
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], bd_options);
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -794,14 +800,14 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['update', id, '--status', status]);
+    const res = await runBd(['update', id, '--status', status], bd_options);
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
       );
       return;
     }
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], bd_options);
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -840,14 +846,17 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['update', id, '--priority', String(priority)]);
+    const res = await runBd(
+      ['update', id, '--priority', String(priority)],
+      bd_options
+    );
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
       );
       return;
     }
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], bd_options);
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -904,14 +913,14 @@ export async function handleMessage(ws, data) {
             : field === 'notes'
               ? '--notes'
               : '--design';
-    const res = await runBd(['update', id, flag, value]);
+    const res = await runBd(['update', id, flag, value], bd_options);
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
       );
       return;
     }
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], bd_options);
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -962,7 +971,7 @@ export async function handleMessage(ws, data) {
     if (typeof description === 'string' && description.length > 0) {
       args.push('-d', description);
     }
-    const res = await runBd(args);
+    const res = await runBd(args, bd_options);
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
@@ -1000,7 +1009,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['dep', 'add', a, b]);
+    const res = await runBd(['dep', 'add', a, b], bd_options);
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
@@ -1008,7 +1017,7 @@ export async function handleMessage(ws, data) {
       return;
     }
     const id = typeof view_id === 'string' && view_id.length > 0 ? view_id : a;
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], bd_options);
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -1044,7 +1053,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['dep', 'remove', a, b]);
+    const res = await runBd(['dep', 'remove', a, b], bd_options);
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
@@ -1052,7 +1061,7 @@ export async function handleMessage(ws, data) {
       return;
     }
     const id = typeof view_id === 'string' && view_id.length > 0 ? view_id : a;
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], bd_options);
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -1088,14 +1097,14 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['label', 'add', id, label.trim()]);
+    const res = await runBd(['label', 'add', id, label.trim()], bd_options);
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
       );
       return;
     }
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], bd_options);
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -1131,14 +1140,14 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['label', 'remove', id, label.trim()]);
+    const res = await runBd(['label', 'remove', id, label.trim()], bd_options);
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
       );
       return;
     }
-    const shown = await runBdJson(['show', id, '--json']);
+    const shown = await runBdJson(['show', id, '--json'], bd_options);
     if (shown.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', shown.stderr || 'bd failed'))
@@ -1165,7 +1174,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBdJson(['comments', id, '--json']);
+    const res = await runBdJson(['comments', id, '--json'], bd_options);
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
@@ -1204,7 +1213,7 @@ export async function handleMessage(ws, data) {
       args.push('--author', author);
     }
 
-    const res = await runBd(args);
+    const res = await runBd(args, bd_options);
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(makeError(req, 'bd_error', res.stderr || 'bd failed'))
@@ -1213,7 +1222,7 @@ export async function handleMessage(ws, data) {
     }
 
     // Return updated comments list
-    const comments = await runBdJson(['comments', id, '--json']);
+    const comments = await runBdJson(['comments', id, '--json'], bd_options);
     if (comments.code !== 0) {
       ws.send(
         JSON.stringify(
@@ -1237,7 +1246,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    const res = await runBd(['delete', id, '--force']);
+    const res = await runBd(['delete', id, '--force'], bd_options);
     if (res.code !== 0) {
       ws.send(
         JSON.stringify(

--- a/server/ws.mutations.test.js
+++ b/server/ws.mutations.test.js
@@ -339,4 +339,43 @@ describe('ws mutation handlers', () => {
     expect(obj.ok).toBe(true);
     expect(obj.payload && obj.payload.created).toBe(true);
   });
+
+  test('write handlers run bd in the active workspace cwd', async () => {
+    const mRun = /** @type {import('vitest').Mock} */ (runBd);
+    const mJson = /** @type {import('vitest').Mock} */ (runBdJson);
+
+    // Set the active workspace first.
+    const ws_setup = makeStubSocket();
+    await handleMessage(
+      /** @type {any} */ (ws_setup),
+      Buffer.from(
+        JSON.stringify({
+          id: 'sw',
+          type: 'set-workspace',
+          payload: { path: '/tmp/bdui-ws-test-fixture' }
+        })
+      )
+    );
+
+    mRun.mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+    mJson.mockResolvedValueOnce({
+      code: 0,
+      stdoutJson: { id: 'UI-7', status: 'in_progress' }
+    });
+    const ws = makeStubSocket();
+    const req = {
+      id: 'r-cwd',
+      type: 'update-status',
+      payload: { id: 'UI-7', status: 'in_progress' }
+    };
+    await handleMessage(
+      /** @type {any} */ (ws),
+      Buffer.from(JSON.stringify(req))
+    );
+
+    expect(mRun).toHaveBeenCalledWith(
+      ['update', 'UI-7', '--status', 'in_progress'],
+      expect.objectContaining({ cwd: '/tmp/bdui-ws-test-fixture' })
+    );
+  });
 });


### PR DESCRIPTION
Fixes #87.

## What was broken

Mutation handlers in `server/ws.js` called `runBd` / `runBdJson` without forwarding a `cwd` option. `bd.js` falls back to `process.cwd()` when no cwd is given, which is the bdui daemon's working directory, not the workspace selected via `set-workspace`. In a Dolt workspace `bd` then exits non-zero with `Error: no beads database found`; the handler sends `bd_error` over the WebSocket, but the client's optimistic dropdown update reverts on refresh and nothing surfaces to the user.

The reason `beads-ui:bd` produced no trace in the daemon log: `runBdJson` logs failed exits, `runBd` did not. So write failures left no debug trail at all.

Same defect on the read side in the `get-comments` handler.

Same failure shape as #67 (comment-add silent fail) and #74 (can't create comment from UI).

## Fix

Two commits.

**1. `fix(ws): pin bd invocations to the active workspace cwd`**

Introduce a single `bd_options` object at the top of `handleMessage` capturing `{ cwd: CURRENT_WORKSPACE?.root_dir }`. Thread it through every `runBd` / `runBdJson` call in `ws.js`. Mirrors the pattern `fetchListForSubscription` already uses on the list-subscription path.

New mutation test drives `set-workspace`, then `update-status`, and asserts the recorded `runBd` call site received the workspace cwd. Existing comment- and delete-handler tests updated to accept the second argument.

**2. `fix(bd): log non-zero exits in runBd for parity with runBdJson`**

Move the existing `runBdJson` exit log into `runBd`'s `child.on('close')` handler so write failures leave a `beads-ui:bd` trace. New unit test enables the namespace, captures stderr, and asserts the log fires on non-zero exit.

## Verification

- `npm run all` green locally: 274 tests pass, lint + tsc + prettier clean.
- New test `write handlers run bd in the active workspace cwd` in `server/ws.mutations.test.js` red→green confirms the contract.
- New test `logs non-zero exit with args and stderr (parity with runBdJson)` in `server/bd.test.js` covers the secondary fix.

## Notes

`CHANGES.md` not updated per `AGENTS.md`.