### PR TITLE
feat(list): inline epic rows in the Issues tab with progress bar and expandable children

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -757,7 +757,9 @@ export function bootstrap(root_element) {
       }
 
       // Epics tab
-      if (s.view === 'epics') {
+      // Keep tab:epics open for Issues view too — Issues renderer looks up
+      // epic progress counters from this snapshot.
+      if (s.view === 'epics' || s.view === 'issues') {
         // Register store first to avoid race with initial snapshot
         try {
           sub_issue_stores.register('tab:epics', { type: 'epics' });

--- a/app/styles.css
+++ b/app/styles.css
@@ -1386,6 +1386,12 @@ input.inline-edit:focus {
   margin-right: 4px;
   font-family: monospace;
 }
+
+/* Placeholder shown when an expanded epic produced no child rows. Reads as
+   a note rather than a row so it is not mistaken for an issue. */
+.epic-child-empty td {
+  font-style: italic;
+}
 .table {
   width: 100%;
   border-collapse: collapse;

--- a/app/styles.css
+++ b/app/styles.css
@@ -1356,6 +1356,36 @@ input.inline-edit:focus {
 .epic-chevron:hover {
   color: var(--text-strong, currentColor);
 }
+
+/* Child rows: deeper indent than the parent's chevron, lighter text,
+   subtle background tint, and a leader marker so children are visually
+   distinct from top-level rows at a glance. */
+.epic-child-row {
+  font-size: 0.88em;
+  background: color-mix(in srgb, var(--panel-bg) 88%, var(--muted) 12%);
+}
+
+.epic-child-row td {
+  color: var(--muted);
+  /* Compact row height: tighten vertical padding from --space-6 default to
+     --space-3 so child rows read denser than top-level/epic rows. */
+  padding-top: var(--space-3);
+  padding-bottom: var(--space-3);
+}
+
+.epic-child-row td:first-child,
+.epic-child-row td:nth-child(3) {
+  padding-left: 36px;
+}
+
+/* Leader marker on the Title cell (column 3) — visually pairs with the
+   chevron position above and reads as a continuation of the title flow. */
+.epic-child-row td:nth-child(3)::before {
+  content: '↳ ';
+  opacity: 0.55;
+  margin-right: 4px;
+  font-family: monospace;
+}
 .table {
   width: 100%;
   border-collapse: collapse;

--- a/app/styles.css
+++ b/app/styles.css
@@ -1316,6 +1316,46 @@ input.inline-edit:focus {
 .epic-children {
   padding: 8px 12px 12px;
 }
+
+/* In-table epic layout: title cell hosts chevron, title text, and progress */
+.epic-title-cell {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.epic-title-cell .epic-title-text {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.epic-title-cell .epic-progress {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.epic-title-cell .epic-progress progress {
+  width: 140px;
+  height: 8px;
+  accent-color: var(--status-closed-base);
+}
+
+.epic-chevron {
+  display: inline-block;
+  width: 14px;
+  text-align: center;
+  user-select: none;
+  cursor: pointer;
+  font-size: 0.9em;
+}
+
+.epic-chevron:hover {
+  color: var(--text-strong, currentColor);
+}
 .table {
   width: 100%;
   border-collapse: collapse;

--- a/app/views/issue-row.js
+++ b/app/views/issue-row.js
@@ -25,7 +25,8 @@ import {
  *   onUpdate: (id: string, patch: { title?: string, assignee?: string, status?: SettableStatus, priority?: number, issue_type?: string }) => Promise<void>,
  *   requestRender: () => void,
  *   getSelectedId?: () => string | null,
- *   row_class?: string
+ *   row_class?: string,
+ *   title_renderer?: (it: IssueRowData) => import('lit-html').TemplateResult<1>
  * }} options
  * @returns {(it: IssueRowData) => import('lit-html').TemplateResult<1>}
  */
@@ -35,6 +36,7 @@ export function createIssueRowRenderer(options) {
   const request_render = options.requestRender;
   const get_selected_id = options.getSelectedId || (() => null);
   const row_class = options.row_class || 'issue-row';
+  const title_renderer = options.title_renderer || null;
 
   /** @type {Set<string>} */
   const editing = new Set();
@@ -170,7 +172,11 @@ export function createIssueRowRenderer(options) {
           )}
         </select>
       </td>
-      <td role="gridcell">${editableText(it.id, 'title', it.title || '')}</td>
+      <td role="gridcell">
+        ${title_renderer
+          ? title_renderer(it)
+          : editableText(it.id, 'title', it.title || '')}
+      </td>
       <td role="gridcell">
         <select
           class="badge-select badge--status is-${cur_status}"

--- a/app/views/list.epic-empty-states.test.js
+++ b/app/views/list.epic-empty-states.test.js
@@ -1,0 +1,330 @@
+import { describe, expect, test } from 'vitest';
+import { createSubscriptionIssueStore } from '../data/subscription-issue-store.js';
+import { createListView } from './list.js';
+
+/**
+ * Minimal push-store harness (mirrors the one in list.test.js).
+ */
+function createTestIssueStores() {
+  /** @type {Map<string, any>} */
+  const stores = new Map();
+  /** @type {Set<() => void>} */
+  const listeners = new Set();
+
+  /**
+   * @param {string} id - Subscription client id.
+   * @returns {any}
+   */
+  function getStore(id) {
+    let s = stores.get(id);
+    if (!s) {
+      s = createSubscriptionIssueStore(id);
+      stores.set(id, s);
+      s.subscribe(() => {
+        for (const fn of Array.from(listeners)) {
+          try {
+            fn();
+          } catch {
+            /* ignore */
+          }
+        }
+      });
+    }
+    return s;
+  }
+
+  return {
+    getStore,
+    /** @param {string} id - Subscription client id. */
+    snapshotFor(id) {
+      return getStore(id).snapshot().slice();
+    },
+    /** @param {() => void} fn - Change listener. */
+    subscribe(fn) {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    }
+  };
+}
+
+/**
+ * Seed a single epic into `tab:issues` plus its counters in `tab:epics`.
+ *
+ * @param {any} stores - Test store harness.
+ * @param {number} total_children - Counter reported by `bd epic status`.
+ * @param {any[]} [extra_issues] - Additional top-level issues.
+ */
+function seedEpic(stores, total_children, extra_issues = []) {
+  stores.getStore('tab:issues').applyPush({
+    type: 'snapshot',
+    id: 'tab:issues',
+    revision: 1,
+    issues: [
+      {
+        id: 'X-EPIC',
+        title: 'Epic A',
+        status: 'open',
+        priority: 1,
+        issue_type: 'epic'
+      },
+      ...extra_issues
+    ]
+  });
+  stores.getStore('tab:epics').applyPush({
+    type: 'snapshot',
+    id: 'tab:epics',
+    revision: 1,
+    issues: [{ id: 'X-EPIC', total_children, closed_children: 0 }]
+  });
+}
+
+/**
+ * Seed the epic's `issue-detail` subscription with children.
+ *
+ * @param {any} stores - Test store harness.
+ * @param {any[]} dependents - Child issues delivered by the detail fetch.
+ */
+function seedChildren(stores, dependents) {
+  stores.getStore('detail:X-EPIC').applyPush({
+    type: 'snapshot',
+    id: 'detail:X-EPIC',
+    revision: 1,
+    issues: [{ id: 'X-EPIC', dependents }]
+  });
+}
+
+/**
+ * Read the placeholder row rendered under an expanded epic, if any.
+ *
+ * @param {HTMLElement} mount - The container element.
+ * @returns {{ state: string, text: string } | null}
+ */
+function placeholder(mount) {
+  const el = mount.querySelector('[data-epic-empty-for="X-EPIC"]');
+  if (!el) {
+    return null;
+  }
+  return {
+    state: el.getAttribute('data-empty-state') || '',
+    text: (el.textContent || '').trim()
+  };
+}
+
+/**
+ * Expand the seeded epic by clicking its chevron.
+ *
+ * @param {HTMLElement} mount - The container element.
+ */
+async function expandEpic(mount) {
+  /** @type {HTMLElement} */ (
+    mount.querySelector('[data-epic-id="X-EPIC"] .epic-chevron')
+  ).click();
+  await Promise.resolve();
+}
+
+/**
+ * Click a status checkbox in the status dropdown.
+ *
+ * @param {HTMLElement} mount - The container element.
+ * @param {string} label - Visible label of the checkbox.
+ */
+function toggleStatus(mount, label) {
+  const dropdown = mount.querySelectorAll('.filter-dropdown')[0];
+  const option = Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--status')
+  ).find((opt) => (opt.textContent || '').trim() === label);
+  const checkbox = /** @type {HTMLInputElement} */ (
+    option?.querySelector('input[type="checkbox"]')
+  );
+  checkbox.click();
+}
+
+/**
+ * Mount the list view against the given stores.
+ *
+ * @param {HTMLElement} mount - The container element.
+ * @param {any} stores - Test store harness.
+ * @param {any} [subscriptions] - Optional subscriptions facade.
+ */
+function mountList(mount, stores, subscriptions = undefined) {
+  return createListView(
+    mount,
+    async () => null,
+    () => {},
+    undefined,
+    subscriptions,
+    stores
+  );
+}
+
+describe('views/list expanded-epic empty states', () => {
+  test('expanded epic whose children never arrive shows a degraded state', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    // Counters say there are 2 children, but the issue-detail fetch delivered
+    // nothing (the production failure mode: every detail fetch erroring out).
+    seedEpic(stores, 2);
+    const view = mountList(mount, stores);
+    await view.load();
+    await expandEpic(mount);
+
+    const ph = placeholder(mount);
+    expect(ph).toBeTruthy();
+    expect(ph?.state).toBe('failed');
+    expect(ph?.text).toBe("Couldn't load children");
+  });
+
+  test('expanded epic with no children at all shows the benign empty state', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    seedEpic(stores, 0);
+    const view = mountList(mount, stores);
+    await view.load();
+    await expandEpic(mount);
+
+    const ph = placeholder(mount);
+    expect(ph).toBeTruthy();
+    expect(ph?.state).toBe('empty');
+    expect(ph?.text).toBe('No children');
+  });
+
+  test('children excluded by the active filter are not reported as a failure', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    // total_children > 0 AND children delivered: only the user's own status
+    // filter empties the list, so this must not read as a load failure.
+    seedEpic(stores, 2);
+    seedChildren(stores, [
+      {
+        id: 'X-2',
+        title: 'open child',
+        status: 'open',
+        priority: 2,
+        issue_type: 'task'
+      },
+      {
+        id: 'X-3',
+        title: 'another open child',
+        status: 'open',
+        priority: 2,
+        issue_type: 'task'
+      }
+    ]);
+    const view = mountList(mount, stores);
+    await view.load();
+    await expandEpic(mount);
+    expect(placeholder(mount)).toBeNull();
+
+    toggleStatus(mount, 'Closed');
+    await Promise.resolve();
+
+    expect(mount.querySelector('[data-issue-id="X-2"]')).toBeFalsy();
+    const ph = placeholder(mount);
+    expect(ph).toBeTruthy();
+    expect(ph?.state).toBe('filtered');
+    expect(ph?.text).not.toContain("Couldn't load");
+  });
+
+  test('expanded epic with delivered children renders rows and no placeholder', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    seedEpic(stores, 2);
+    seedChildren(stores, [
+      {
+        id: 'X-2',
+        title: 'child one',
+        status: 'open',
+        priority: 2,
+        issue_type: 'task'
+      },
+      {
+        id: 'X-3',
+        title: 'child two',
+        status: 'closed',
+        priority: 2,
+        issue_type: 'task'
+      }
+    ]);
+    const view = mountList(mount, stores);
+    await view.load();
+    await expandEpic(mount);
+
+    expect(mount.querySelector('[data-issue-id="X-2"]')).toBeTruthy();
+    expect(mount.querySelector('[data-issue-id="X-3"]')).toBeTruthy();
+    expect(mount.querySelectorAll('tr.epic-child-row').length).toBe(2);
+    expect(placeholder(mount)).toBeNull();
+  });
+
+  test('collapsed epic still hides its children from the top level', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    seedEpic(stores, 2, [
+      {
+        id: 'X-2',
+        title: 'Child One',
+        status: 'open',
+        priority: 2,
+        issue_type: 'task',
+        parent: 'X-EPIC'
+      },
+      {
+        id: 'X-3',
+        title: 'Child Two',
+        status: 'open',
+        priority: 2,
+        issue_type: 'task',
+        parent: 'X-EPIC'
+      },
+      {
+        id: 'X-4',
+        title: 'Standalone',
+        status: 'open',
+        priority: 2,
+        issue_type: 'task'
+      }
+    ]);
+    const view = mountList(mount, stores);
+    await view.load();
+
+    // Nothing expanded: children stay hidden and no placeholder appears.
+    expect(mount.querySelector('[data-issue-id="X-EPIC"]')).toBeTruthy();
+    expect(mount.querySelector('[data-issue-id="X-4"]')).toBeTruthy();
+    expect(mount.querySelector('[data-issue-id="X-2"]')).toBeFalsy();
+    expect(mount.querySelector('[data-issue-id="X-3"]')).toBeFalsy();
+    expect(placeholder(mount)).toBeNull();
+  });
+
+  test('in-flight detail fetch shows loading, not the failure state', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    seedEpic(stores, 2);
+    /** @type {(v: any) => void} */
+    let settle = () => {};
+    const subscriptions = {
+      /** @returns {Promise<() => Promise<void>>} */
+      subscribeList: () =>
+        new Promise((resolve) => {
+          settle = resolve;
+        })
+    };
+    const view = mountList(mount, stores, subscriptions);
+    await view.load();
+    await expandEpic(mount);
+
+    const pending = placeholder(mount);
+    expect(pending?.state).toBe('loading');
+    expect(pending?.text).not.toContain("Couldn't load");
+
+    // The fetch settles without delivering children -> degraded state.
+    settle(async () => {});
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(placeholder(mount)?.state).toBe('failed');
+  });
+});

--- a/app/views/list.js
+++ b/app/views/list.js
@@ -29,7 +29,10 @@ import { createIssueRowRenderer } from './issue-row.js';
  * @param {(type: string, payload?: unknown) => Promise<unknown>} sendFn - RPC transport.
  * @param {(hash: string) => void} [navigate_fn] - Navigation function (defaults to setting location.hash).
  * @param {{ getState: () => any, setState: (patch: any) => void, subscribe: (fn: (s:any)=>void)=>()=>void }} [store] - Optional state store.
- * @param {{ selectors: { getIds: (client_id: string) => string[] } }} [_subscriptions]
+ * @param {{
+ *   selectors?: { getIds?: (client_id: string) => string[] },
+ *   subscribeList?: (client_id: string, spec: { type: string, params?: Record<string, string|number|boolean> }) => Promise<() => Promise<void>>
+ * }} [subscriptions]
  * @param {{ snapshotFor?: (client_id: string) => any[], subscribe?: (fn: () => void) => () => void }} [issueStores]
  * @returns {{ load: () => Promise<void>, destroy: () => void }} View API.
  */
@@ -40,7 +43,10 @@ import { createIssueRowRenderer } from './issue-row.js';
  * @param {(type: string, payload?: unknown) => Promise<unknown>} sendFn
  * @param {(hash: string) => void} [navigateFn]
  * @param {{ getState: () => any, setState: (patch: any) => void, subscribe: (fn: (s:any)=>void)=>()=>void }} [store]
- * @param {{ selectors: { getIds: (client_id: string) => string[] } }} [_subscriptions]
+ * @param {{
+ *   selectors?: { getIds?: (client_id: string) => string[] },
+ *   subscribeList?: (client_id: string, spec: { type: string, params?: Record<string, string|number|boolean> }) => Promise<() => Promise<void>>
+ * }} [subscriptions]
  * @param {{ snapshotFor?: (client_id: string) => any[], subscribe?: (fn: () => void) => () => void }} [issue_stores]
  * @returns {{ load: () => Promise<void>, destroy: () => void }}
  */
@@ -49,12 +55,10 @@ export function createListView(
   sendFn,
   navigateFn,
   store,
-  _subscriptions = undefined,
+  subscriptions = undefined,
   issue_stores = undefined
 ) {
   const log = debug('views:list');
-  // Touch unused param to satisfy lint rules without impacting behavior
-  /** @type {any} */ (void _subscriptions);
   /** @type {StatusFilter[]} */
   let status_filters = [];
   /** @type {string} */
@@ -65,6 +69,12 @@ export function createListView(
   let type_filters = [];
   /** @type {string | null} */
   let selected_id = store ? store.getState().selected_id : null;
+  /** @type {Set<string>} */
+  const expanded = new Set();
+  /** @type {Set<string>} */
+  const loading = new Set();
+  /** @type {Map<string, () => Promise<void>>} */
+  const epic_unsubs = new Map();
   /** @type {null | (() => void)} */
   let unsubscribe = null;
   let status_dropdown_open = false;
@@ -82,18 +92,82 @@ export function createListView(
     return [];
   }
 
-  // Shared row renderer (used in template below)
+  /**
+   * Build navigate handler shared by all three row renderers.
+   *
+   * @param {string} id
+   */
+  function navigateToIssue(id) {
+    const nav = navigateFn || ((h) => (window.location.hash = h));
+    /** @type {'issues'|'epics'|'board'} */
+    const view = store ? store.getState().view : 'issues';
+    nav(issueHashFor(view, id));
+  }
+
+  // Shared row renderer for non-epic top-level rows
   const row_renderer = createIssueRowRenderer({
-    navigate: (id) => {
-      const nav = navigateFn || ((h) => (window.location.hash = h));
-      /** @type {'issues'|'epics'|'board'} */
-      const view = store ? store.getState().view : 'issues';
-      nav(issueHashFor(view, id));
-    },
+    navigate: navigateToIssue,
     onUpdate: updateInline,
     requestRender: doRender,
     getSelectedId: () => selected_id,
     row_class: 'issue-row'
+  });
+
+  // Child rows are canonical rows with an extra class for visual differentiation
+  const child_row_renderer = createIssueRowRenderer({
+    navigate: navigateToIssue,
+    onUpdate: updateInline,
+    requestRender: doRender,
+    getSelectedId: () => selected_id,
+    row_class: 'issue-row epic-child-row'
+  });
+
+  // Epic rows use the canonical pipeline but inject a custom title cell
+  // (chevron + title text + progress bar). Only the chevron toggles expand.
+  const epic_row_renderer = createIssueRowRenderer({
+    navigate: navigateToIssue,
+    onUpdate: updateInline,
+    requestRender: doRender,
+    getSelectedId: () => selected_id,
+    row_class: 'issue-row epic-row-inline',
+    title_renderer: /** @param {{ id: string, title?: string }} it */ (it) => {
+      const id = String(it.id);
+      const is_open = expanded.has(id);
+      const { total, closed } = getEpicCounters(id);
+      return html`
+        <span class="epic-title-cell" data-epic-id=${id}>
+          <span
+            class="epic-chevron"
+            role="button"
+            tabindex="0"
+            aria-expanded=${is_open ? 'true' : 'false'}
+            aria-label=${is_open ? 'Collapse epic' : 'Expand epic'}
+            @click=${
+              /** @param {Event} ev */ (ev) => {
+                ev.stopPropagation();
+                ev.preventDefault();
+                void toggleEpic(id);
+              }
+            }
+            @keydown=${
+              /** @param {KeyboardEvent} ev */ (ev) => {
+                if (ev.key === 'Enter' || ev.key === ' ') {
+                  ev.preventDefault();
+                  ev.stopPropagation();
+                  void toggleEpic(id);
+                }
+              }
+            }
+            >${is_open ? '▾' : '▸'}</span
+          >
+          <span class="epic-title-text">${it.title || ''}</span>
+          <span class="epic-progress">
+            <progress value=${closed} max=${Math.max(1, total)}></progress>
+            <span class="muted mono">${closed}/${total}</span>
+          </span>
+        </span>
+      `;
+    }
   });
 
   /**
@@ -227,6 +301,115 @@ export function createListView(
   const selectors = issue_stores ? createListSelectors(issue_stores) : null;
 
   /**
+   * Look up counters for an epic from the tab:epics snapshot.
+   * Returns {total: 0, closed: 0} if the epic isn't in the snapshot yet
+   * (race condition during initial load — progress bar will update on
+   * the next push when tab:epics arrives).
+   *
+   * @param {string} epic_id
+   */
+  function getEpicCounters(epic_id) {
+    if (!issue_stores || typeof issue_stores.snapshotFor !== 'function') {
+      return { total: 0, closed: 0 };
+    }
+    const arr = issue_stores.snapshotFor('tab:epics') || [];
+    const meta = arr.find((e) => String(e?.id || '') === String(epic_id));
+    if (!meta) return { total: 0, closed: 0 };
+    return {
+      total: Number(/** @type {any} */ (meta).total_children || 0),
+      closed: Number(/** @type {any} */ (meta).closed_children || 0)
+    };
+  }
+
+  /**
+   * Partition the (filtered ∪ expanded-epics) list into:
+   *  - epic_rows: items with issue_type === 'epic' (rendered with header + optional children)
+   *  - top_level_rows: non-epic items WHOSE PARENT IS NOT IN epic_ids
+   *  - (children of epics in epic_ids are rendered inline under their epic when expanded)
+   *
+   * Recovers any expanded epic that the filter excluded — expanded epics
+   * always render so their (possibly-matching) children remain reachable.
+   *
+   * @param {Issue[]} filtered - Items that passed the top-level filter
+   * @param {Issue[]} all - The full issues_cache (used to recover expanded-but-filtered epics)
+   */
+  function partitionForTree(filtered, all) {
+    const filtered_ids = new Set(filtered.map((it) => String(it.id)));
+    /** @type {Issue[]} */
+    const recovered = [];
+    for (const ep of all) {
+      if (String(ep.issue_type || '') !== 'epic') continue;
+      const id = String(ep.id);
+      if (expanded.has(id) && !filtered_ids.has(id)) {
+        recovered.push(ep);
+      }
+    }
+    const effective = filtered.concat(recovered);
+
+    const epic_ids = new Set(
+      effective
+        .filter((it) => String(it.issue_type || '') === 'epic')
+        .map((it) => String(it.id))
+    );
+    /** @type {Issue[]} */
+    const epic_rows = [];
+    /** @type {Issue[]} */
+    const top_level_rows = [];
+    for (const it of effective) {
+      const is_epic = String(it.issue_type || '') === 'epic';
+      if (is_epic) {
+        epic_rows.push(it);
+        continue;
+      }
+      const parent = String(/** @type {any} */ (it).parent || '');
+      if (parent && epic_ids.has(parent)) {
+        continue; // Hidden — will appear under its epic if expanded
+      }
+      top_level_rows.push(it);
+    }
+    return { epic_rows, top_level_rows, epic_ids };
+  }
+
+  /**
+   * Apply current filters to a list of issues (used for child filtering).
+   *
+   * Intentionally narrower than the top-level filter:
+   *  - No 'ready' branch — 'ready' is a top-level membership concept, not a per-row predicate.
+   *    Children inherit visibility from their epic's filter pass.
+   *  - No closed-sort branch — children sort within their parent epic; closed-only sort
+   *    is a list-level concern, not a child concern.
+   *
+   * @param {Issue[]} list
+   */
+  function applyFiltersToIssues(list) {
+    let out = list;
+    // Mirrors `template()`: 'ready' is a server-side membership, never a row
+    // predicate, so it is stripped before the stored statuses narrow the rows.
+    const stored_status_filters = status_filters.filter((s) => s !== 'ready');
+    if (stored_status_filters.length > 0) {
+      out = out.filter((it) =>
+        /** @type {string[]} */ (stored_status_filters).includes(
+          String(it.status || '')
+        )
+      );
+    }
+    if (search_text) {
+      const needle = search_text.toLowerCase();
+      out = out.filter((it) => {
+        const a = String(it.id).toLowerCase();
+        const b = String(it.title || '').toLowerCase();
+        return a.includes(needle) || b.includes(needle);
+      });
+    }
+    if (type_filters.length > 0) {
+      out = out.filter((it) =>
+        type_filters.includes(String(it.issue_type || ''))
+      );
+    }
+    return out;
+  }
+
+  /**
    * Build lit-html template for the list view.
    */
   function template() {
@@ -262,6 +445,43 @@ export function createListView(
       stored_status_filters[0] === 'closed'
     ) {
       filtered = filtered.slice().sort(cmpClosedDesc);
+    }
+
+    const { epic_rows, top_level_rows } = partitionForTree(
+      filtered,
+      issues_cache
+    );
+
+    // Merge epics and non-epic top-level rows by the existing priority/created sort.
+    const merged = [...epic_rows, ...top_level_rows].sort((a, b) => {
+      const pa = a.priority ?? 2;
+      const pb = b.priority ?? 2;
+      if (pa !== pb) return pa - pb;
+      const ca = /** @type {any} */ (a).created_at ?? 0;
+      const cb = /** @type {any} */ (b).created_at ?? 0;
+      if (ca !== cb) return ca < cb ? -1 : 1;
+      return String(a.id) < String(b.id) ? -1 : 1;
+    });
+
+    /** @type {import('lit-html').TemplateResult<1>[]} */
+    const rows_array = [];
+    for (const it of merged) {
+      if (String(it.issue_type || '') === 'epic') {
+        rows_array.push(epic_row_renderer(it));
+        if (expanded.has(String(it.id))) {
+          const children = selectors
+            ? selectors.selectEpicChildren(String(it.id))
+            : [];
+          const filtered_children = applyFiltersToIssues(
+            /** @type {Issue[]} */ (children)
+          );
+          for (const child of filtered_children) {
+            rows_array.push(child_row_renderer(child));
+          }
+        }
+      } else {
+        rows_array.push(row_renderer(it));
+      }
     }
 
     return html`
@@ -356,7 +576,7 @@ export function createListView(
         />
       </div>
       <div class="panel__body" id="list-root">
-        ${filtered.length === 0
+        ${rows_array.length === 0
           ? html`<div class="issues-block">
               <div class="muted" style="padding:10px 12px;">No issues</div>
             </div>`
@@ -364,7 +584,7 @@ export function createListView(
               <table
                 class="table"
                 role="grid"
-                aria-rowcount=${String(filtered.length)}
+                aria-rowcount=${String(rows_array.length)}
                 aria-colcount="6"
               >
                 <colgroup>
@@ -388,7 +608,7 @@ export function createListView(
                   </tr>
                 </thead>
                 <tbody role="rowgroup">
-                  ${filtered.map((it) => row_renderer(it))}
+                  ${rows_array}
                 </tbody>
               </table>
             </div>`}
@@ -435,6 +655,62 @@ export function createListView(
     } catch {
       // ignore failures; UI state remains as-is
     }
+  }
+
+  /**
+   * Toggle expanded state for an epic row.
+   *
+   * @param {string} epic_id
+   */
+  async function toggleEpic(epic_id) {
+    if (!expanded.has(epic_id)) {
+      expanded.add(epic_id);
+      loading.add(epic_id);
+      doRender();
+      if (
+        subscriptions &&
+        typeof (/** @type {any} */ (subscriptions).subscribeList) === 'function'
+      ) {
+        try {
+          if (issue_stores && /** @type {any} */ (issue_stores).register) {
+            /** @type {any} */ (issue_stores).register(`detail:${epic_id}`, {
+              type: 'issue-detail',
+              params: { id: epic_id }
+            });
+          }
+          const u = await /** @type {any} */ (subscriptions).subscribeList(
+            `detail:${epic_id}`,
+            {
+              type: 'issue-detail',
+              params: { id: epic_id }
+            }
+          );
+          epic_unsubs.set(epic_id, u);
+        } catch {
+          // ignore subscription failures
+        }
+      }
+      loading.delete(epic_id);
+    } else {
+      expanded.delete(epic_id);
+      const u = epic_unsubs.get(epic_id);
+      if (u) {
+        try {
+          await u();
+        } catch {
+          /* ignore */
+        }
+        epic_unsubs.delete(epic_id);
+      }
+      if (issue_stores && /** @type {any} */ (issue_stores).unregister) {
+        try {
+          /** @type {any} */ (issue_stores).unregister(`detail:${epic_id}`);
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+    doRender();
   }
 
   /**
@@ -650,6 +926,15 @@ export function createListView(
   return {
     load,
     destroy() {
+      for (const u of epic_unsubs.values()) {
+        try {
+          void u();
+        } catch {
+          /* ignore */
+        }
+      }
+      epic_unsubs.clear();
+      expanded.clear();
       mount_element.replaceChildren();
       document.removeEventListener('click', clickOutsideHandler);
       if (unsubscribe) {

--- a/app/views/list.js
+++ b/app/views/list.js
@@ -322,6 +322,55 @@ export function createListView(
   }
 
   /**
+   * Placeholder row for an expanded epic that produced no child rows.
+   *
+   * Rendering nothing here is a silent failure: `partitionForTree` hides an
+   * epic's children from the top-level list, so a detail fetch that never
+   * delivers makes those issues vanish from the UI entirely with no signal
+   * (observed in production as "my issue list is truncated").
+   *
+   * @param {string} epic_id
+   * @param {string} state - `loading` | `failed` | `filtered` | `empty`.
+   * @param {string} message
+   */
+  function epicEmptyRow(epic_id, state, message) {
+    return html`
+      <tr
+        class="epic-child-row epic-child-empty"
+        data-epic-empty-for=${epic_id}
+        data-empty-state=${state}
+      >
+        <td colspan="7" class="muted">${message}</td>
+      </tr>
+    `;
+  }
+
+  /**
+   * Classify why an expanded epic rendered no child rows.
+   *
+   * The three outcomes must stay distinct: a filter the user applied is not a
+   * failure, and an epic that genuinely has no children is not one either.
+   * `total` comes from the same `tab:epics` counters the progress bar uses.
+   *
+   * @param {string} epic_id
+   * @param {number} delivered - Children the detail subscription delivered.
+   * @returns {{ state: string, message: string }}
+   */
+  function classifyEmptyEpic(epic_id, delivered) {
+    if (loading.has(epic_id)) {
+      return { state: 'loading', message: 'Loading…' };
+    }
+    if (delivered > 0) {
+      return { state: 'filtered', message: 'No children match the filters' };
+    }
+    const { total } = getEpicCounters(epic_id);
+    if (total > 0) {
+      return { state: 'failed', message: `Couldn't load children` };
+    }
+    return { state: 'empty', message: 'No children' };
+  }
+
+  /**
    * Partition the (filtered ∪ expanded-epics) list into:
    *  - epic_rows: items with issue_type === 'epic' (rendered with header + optional children)
    *  - top_level_rows: non-epic items WHOSE PARENT IS NOT IN epic_ids
@@ -475,6 +524,13 @@ export function createListView(
           const filtered_children = applyFiltersToIssues(
             /** @type {Issue[]} */ (children)
           );
+          if (filtered_children.length === 0) {
+            const { state, message } = classifyEmptyEpic(
+              String(it.id),
+              children.length
+            );
+            rows_array.push(epicEmptyRow(String(it.id), state, message));
+          }
           for (const child of filtered_children) {
             rows_array.push(child_row_renderer(child));
           }

--- a/app/views/list.test.js
+++ b/app/views/list.test.js
@@ -719,6 +719,192 @@ describe('views/list', () => {
     expect(rows).toEqual(['UI-1', 'UI-2']);
   });
 
+  test('clicking epic chevron toggles expanded state', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    stores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: [
+        {
+          id: 'X-1',
+          title: 'Epic A',
+          status: 'open',
+          priority: 1,
+          issue_type: 'epic'
+        }
+      ]
+    });
+    // Counters live in tab:epics (separate subscription backed by `bd epic status`)
+    stores.getStore('tab:epics').applyPush({
+      type: 'snapshot',
+      id: 'tab:epics',
+      revision: 1,
+      issues: [{ id: 'X-1', total_children: 3, closed_children: 1 }]
+    });
+    const view = createListView(
+      mount,
+      async () => null,
+      () => {},
+      undefined,
+      undefined,
+      stores
+    );
+    await view.load();
+    const chevron = mount.querySelector('[data-epic-id="X-1"] .epic-chevron');
+    expect(chevron).toBeTruthy();
+    expect(chevron?.getAttribute('aria-expanded')).toBe('false');
+    /** @type {HTMLElement} */ (chevron).click();
+    await Promise.resolve();
+    expect(chevron?.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  test('clicking epic chevron twice collapses (toggle is bidirectional)', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    stores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: [
+        {
+          id: 'X-1',
+          title: 'Epic A',
+          status: 'open',
+          priority: 1,
+          issue_type: 'epic'
+        }
+      ]
+    });
+    stores.getStore('tab:epics').applyPush({
+      type: 'snapshot',
+      id: 'tab:epics',
+      revision: 1,
+      issues: [{ id: 'X-1', total_children: 1, closed_children: 0 }]
+    });
+    // Seed children so the expand path has something to render.
+    stores.getStore('detail:X-1').applyPush({
+      type: 'snapshot',
+      id: 'detail:X-1',
+      revision: 1,
+      issues: [
+        {
+          id: 'X-1',
+          dependents: [
+            {
+              id: 'X-2',
+              title: 'child',
+              status: 'open',
+              priority: 2,
+              issue_type: 'task'
+            }
+          ]
+        }
+      ]
+    });
+    const view = createListView(
+      mount,
+      async () => null,
+      () => {},
+      undefined,
+      undefined,
+      stores
+    );
+    await view.load();
+
+    const chevron = mount.querySelector('[data-epic-id="X-1"] .epic-chevron');
+    expect(chevron).toBeTruthy();
+
+    // Click 1: expand
+    /** @type {HTMLElement} */ (chevron).click();
+    await Promise.resolve();
+    expect(chevron?.getAttribute('aria-expanded')).toBe('true');
+
+    // Click 2: collapse
+    /** @type {HTMLElement} */ (chevron).click();
+    await Promise.resolve();
+    expect(chevron?.getAttribute('aria-expanded')).toBe('false');
+    // Child row no longer in DOM after collapse
+    expect(mount.querySelector('[data-issue-id="X-2"]')).toBeFalsy();
+  });
+
+  test('epic row renders progress bar and hides child duplicates', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    stores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: [
+        {
+          id: 'X-EPIC',
+          title: 'Epic A',
+          status: 'open',
+          priority: 1,
+          issue_type: 'epic'
+        },
+        // Child rows present in the flat list (should be hidden because parent is in list)
+        {
+          id: 'X-2',
+          title: 'Child One',
+          status: 'open',
+          priority: 2,
+          issue_type: 'task',
+          parent: 'X-EPIC'
+        },
+        {
+          id: 'X-3',
+          title: 'Child Two',
+          status: 'closed',
+          priority: 2,
+          issue_type: 'task',
+          parent: 'X-EPIC'
+        },
+        // Non-child top-level row (should remain visible)
+        {
+          id: 'X-4',
+          title: 'Standalone',
+          status: 'open',
+          priority: 2,
+          issue_type: 'task'
+        }
+      ]
+    });
+    // Counters live in tab:epics
+    stores.getStore('tab:epics').applyPush({
+      type: 'snapshot',
+      id: 'tab:epics',
+      revision: 1,
+      issues: [{ id: 'X-EPIC', total_children: 2, closed_children: 1 }]
+    });
+    const view = createListView(
+      mount,
+      async () => null,
+      () => {},
+      undefined,
+      undefined,
+      stores
+    );
+    await view.load();
+
+    // Epic row present with progress bar
+    const epicRow = mount.querySelector('[data-issue-id="X-EPIC"]');
+    expect(epicRow).toBeTruthy();
+    expect(epicRow?.querySelector('progress')).toBeTruthy();
+    expect(epicRow?.textContent).toContain('1/2');
+
+    // Children X-2 and X-3 hidden from top-level (no rows with their IDs)
+    expect(mount.querySelector('[data-issue-id="X-2"]')).toBeFalsy();
+    expect(mount.querySelector('[data-issue-id="X-3"]')).toBeFalsy();
+
+    // Standalone visible
+    expect(mount.querySelector('[data-issue-id="X-4"]')).toBeTruthy();
+  });
+
   test('deselecting all checkboxes shows all issues', async () => {
     document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
     const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
@@ -834,5 +1020,230 @@ describe('views/list', () => {
     const rows = mount.querySelectorAll('tr.issue-row');
     expect(rows.length).toBe(1);
     expect(rows[0].getAttribute('data-issue-id')).toBe('UI-2');
+  });
+
+  test('status filter applies to expanded children (expanded epic persists)', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    // Epic is open — would be filtered out by 'Closed' filter without the
+    // expanded-epics-always-render rule. Test exercises both child filtering
+    // AND the expanded-epic recovery branch in partitionForTree.
+    stores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: [
+        {
+          id: 'X-EPIC',
+          title: 'Epic',
+          status: 'open',
+          priority: 1,
+          issue_type: 'epic'
+        }
+      ]
+    });
+    stores.getStore('tab:epics').applyPush({
+      type: 'snapshot',
+      id: 'tab:epics',
+      revision: 1,
+      issues: [{ id: 'X-EPIC', total_children: 2, closed_children: 1 }]
+    });
+    // Seed children into the epic's detail store
+    // (selectEpicChildren reads `detail:${id}` and returns the entry whose id === epic_id, .dependents)
+    stores.getStore('detail:X-EPIC').applyPush({
+      type: 'snapshot',
+      id: 'detail:X-EPIC',
+      revision: 1,
+      issues: [
+        {
+          id: 'X-EPIC',
+          dependents: [
+            {
+              id: 'X-2',
+              title: 'open child',
+              status: 'open',
+              priority: 2,
+              issue_type: 'task'
+            },
+            {
+              id: 'X-3',
+              title: 'closed child',
+              status: 'closed',
+              priority: 2,
+              issue_type: 'task'
+            }
+          ]
+        }
+      ]
+    });
+    const view = createListView(
+      mount,
+      async () => null,
+      () => {},
+      undefined,
+      undefined,
+      stores
+    );
+    await view.load();
+
+    // Expand the epic
+    /** @type {HTMLElement} */ (
+      mount.querySelector('[data-epic-id="X-EPIC"] .epic-chevron')
+    ).click();
+    await Promise.resolve();
+
+    // Both children visible initially
+    expect(mount.querySelector('[data-issue-id="X-2"]')).toBeTruthy();
+    expect(mount.querySelector('[data-issue-id="X-3"]')).toBeTruthy();
+
+    // Apply Closed filter
+    toggleFilter(mount, 0, 'Closed');
+    await Promise.resolve();
+
+    // Epic should still render (expanded epics always render — Key Decision)
+    expect(mount.querySelector('[data-epic-id="X-EPIC"]')).toBeTruthy();
+    // Open child hidden, closed child visible
+    expect(mount.querySelector('[data-issue-id="X-2"]')).toBeFalsy();
+    expect(mount.querySelector('[data-issue-id="X-3"]')).toBeTruthy();
+  });
+
+  test('non-expanded epic filtered out hides entirely (top-level filter still works)', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    stores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: [
+        {
+          id: 'X-EPIC',
+          title: 'Epic',
+          status: 'open',
+          priority: 1,
+          issue_type: 'epic'
+        },
+        {
+          id: 'X-5',
+          title: 'closed task',
+          status: 'closed',
+          priority: 2,
+          issue_type: 'task'
+        }
+      ]
+    });
+    stores.getStore('tab:epics').applyPush({
+      type: 'snapshot',
+      id: 'tab:epics',
+      revision: 1,
+      issues: [{ id: 'X-EPIC', total_children: 1, closed_children: 0 }]
+    });
+    const view = createListView(
+      mount,
+      async () => null,
+      () => {},
+      undefined,
+      undefined,
+      stores
+    );
+    await view.load();
+
+    // Apply Closed filter — open epic was never expanded, so should be filtered out
+    toggleFilter(mount, 0, 'Closed');
+    await Promise.resolve();
+
+    expect(mount.querySelector('[data-epic-id="X-EPIC"]')).toBeFalsy();
+    expect(mount.querySelector('[data-issue-id="X-5"]')).toBeTruthy();
+  });
+
+  test('no auto-expand on initial load', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    stores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: [
+        {
+          id: 'X-EPIC',
+          title: 'E',
+          status: 'open',
+          priority: 1,
+          issue_type: 'epic'
+        }
+      ]
+    });
+    stores.getStore('tab:epics').applyPush({
+      type: 'snapshot',
+      id: 'tab:epics',
+      revision: 1,
+      issues: [{ id: 'X-EPIC', total_children: 1, closed_children: 0 }]
+    });
+    const view = createListView(
+      mount,
+      async () => null,
+      () => {},
+      undefined,
+      undefined,
+      stores
+    );
+    await view.load();
+
+    const chevron = mount.querySelector(
+      '[data-epic-id="X-EPIC"] .epic-chevron'
+    );
+    expect(chevron?.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  test('clicking epic title (not chevron) navigates instead of expanding', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const stores = createTestIssueStores();
+    stores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: [
+        {
+          id: 'X-1',
+          title: 'Epic A',
+          status: 'open',
+          priority: 1,
+          issue_type: 'epic'
+        }
+      ]
+    });
+    stores.getStore('tab:epics').applyPush({
+      type: 'snapshot',
+      id: 'tab:epics',
+      revision: 1,
+      issues: [{ id: 'X-1', total_children: 1, closed_children: 0 }]
+    });
+    const view = createListView(
+      mount,
+      async () => null,
+      () => {},
+      undefined,
+      undefined,
+      stores
+    );
+    await view.load();
+
+    // Title text uses a span (no inline edit on epic rows — title_renderer
+    // emits a plain text span); clicking it should bubble to the row click
+    // handler and navigate, NOT expand the epic.
+    const titleText = mount.querySelector(
+      '[data-issue-id="X-1"] .epic-title-text'
+    );
+    expect(titleText).toBeTruthy();
+    const chevron = mount.querySelector('[data-issue-id="X-1"] .epic-chevron');
+    expect(chevron?.getAttribute('aria-expanded')).toBe('false');
+
+    // Click title — should NOT expand (chevron's click target is independent)
+    /** @type {HTMLElement} */ (titleText).click();
+    await Promise.resolve();
+    expect(chevron?.getAttribute('aria-expanded')).toBe('false');
   });
 });


### PR DESCRIPTION
## Summary

Brings the Epics-tab tree pattern into the Issues tab. Epic rows in the Issues list now render with a chevron and a closed/total progress bar inline, and expand to show their children in place. Children whose parent epic is shown in the same list get hidden from the top-level rows so they don't appear twice. Matches `bd list --tree`.

I spend most of my time in the Issues tab where epics get interleaved with other rows by priority. The Epics tab is great when I want to see only epics, but I reach for the Issues tab daily and the lack of inline visibility was annoying me. The "5/9 children closed" hint and being able to expand without leaving the list is a small thing I reach for constantly now.

## Behaviour

- The chevron toggles expand/collapse. The rest of the row navigates or enters edit mode like any other row.
- The progress bar shows closed/total in the title cell. Counters come from the `tab:epics` snapshot (`bd epic status`). `tab:issues` (backed by `bd list --tree=false`) doesn't carry them.
- Child rows render inline below an expanded epic with a subtle visual treatment (lighter text, deeper indent, leader marker, smaller font) so the parent/child hierarchy reads at a glance.
- No auto-expand on initial load. The Epics tab auto-expands the first row, which is nice for a homogeneous list of epics but disruptive in the heterogeneous Issues view.
- Status, type, and search filters apply to both top-level rows and expanded children. An expanded epic always renders even when the top-level filter would otherwise hide it. Without that, applying "Status: closed" to an open epic with closed children would make those children unreachable.

## Implementation notes worth flagging

`createIssueRowRenderer` gains an optional `title_renderer` callback. The epic-row variant uses it to inject the chevron, title, and progress bar while keeping every other behaviour (status/priority selects, editable title fallback, navigate-on-row-click) inherited from the canonical row. Child rows reuse the canonical renderer with a different `row_class`. No duplicated inline-edit logic.

The Issues view needs `tab:epics` open for counters. `tab:issues` doesn't carry `total_children` / `closed_children`. Easiest fix is to keep the existing `tab:epics` subscription alive whenever the user is on either tab, and have the renderer look up counters by epic id from that snapshot.

The "expanded epic persists through top-level filter" rule needs `partitionForTree` to recover any expanded epic from the full `issues_cache` even when the active filter excluded it. Two tests cover both directions.

Visual styling uses existing CSS variables (`--muted`, `--panel-bg`, `--space-*`) so dark-mode theming carries through.

## Opinionated choices

A few judgment calls I'd happily revise if you'd prefer differently:

- The visual differentiation for child rows (light background tint, leader marker, smaller font) is in a separate commit. Easy to drop if you want a lighter touch.
- The `↳` Unicode leader is intentional. Some TUI tools use it to mark continuation. If you'd prefer no marker or a different glyph, easy swap.
- Children render slightly dimmer (muted text colour) so they read as "under" the parent. If you want them as equal first-class rows, drop the `.epic-child-row td { color: var(--muted) }` rule.

## Test plan

```
npm run lint
npm run tsc
npm test         # 279 passed (incl. 7 new for this feature)
npm run prettier:check
```

Seven new tests cover: chevron click toggles, bidirectional toggle, title click does not expand, child duplicates hidden from top-level, status filter applies to expanded children plus expanded epic persists, non-expanded epic still respects the top-level filter, no auto-expand on initial load.

Also tested live in a browser against a real `bd` workspace with multiple epics and mixed parent/child relationships.

## Commits

1. `feat(list): inline epic rows with progress bar and expandable children`
2. `style(list): differentiate child rows from top-level (greyscale + leader)`

Split so you can cherry-pick the polish separately if you'd rather merge that as a smaller follow-up.
