### PR TITLE
Add a dates card to the issue detail view

### DIFF
--- a/app/views/detail.dates.test.js
+++ b/app/views/detail.dates.test.js
@@ -1,0 +1,205 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createDetailView, formatDateValue } from './detail.js';
+
+/** @type {(impl: (type: string, payload?: unknown) => Promise<any>) => (type: string, payload?: unknown) => Promise<any>} */
+const mockSend = (impl) => vi.fn(impl);
+
+/**
+ * Mount the detail view with a given issue object and return the mount element.
+ *
+ * @param {Record<string, unknown> & { id: string }} issue
+ * @returns {Promise<HTMLElement>}
+ */
+async function mountIssue(issue) {
+  document.body.innerHTML =
+    '<section class="panel"><div id="mount"></div></section>';
+  const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+  const client_id = `detail:${issue.id}`;
+  const stores = {
+    /** @param {string} id */
+    snapshotFor(id) {
+      return id === client_id ? [issue] : [];
+    },
+    subscribe() {
+      return () => {};
+    }
+  };
+  const send = mockSend(async () => {
+    throw new Error('Unexpected send');
+  });
+  const view = createDetailView(mount, send, undefined, stores);
+  await view.load(issue.id);
+  return mount;
+}
+
+/**
+ * Find the Dates card root element.
+ *
+ * @param {HTMLElement} mount
+ * @returns {Element | null}
+ */
+function datesCard(mount) {
+  const titles = Array.from(mount.querySelectorAll('.props-card__title'));
+  const title = titles.find((t) => t.textContent === 'Dates');
+  return title ? title.closest('.props-card') : null;
+}
+
+/**
+ * Return the value text for a labeled row inside the Dates card.
+ *
+ * @param {Element} card
+ * @param {string} label
+ * @returns {string | null}
+ */
+function rowValue(card, label) {
+  const rows = Array.from(card.querySelectorAll('.prop'));
+  for (const row of rows) {
+    const l = row.querySelector('.label');
+    if (l && l.textContent === label) {
+      const v = row.querySelector('.value');
+      return v ? (v.textContent || '').trim() : '';
+    }
+  }
+  return null;
+}
+
+describe('formatDateValue', () => {
+  test('formats a numeric epoch-ms timestamp', () => {
+    // 2026-06-15T12:00:00Z — mid-day UTC, day stable across timezones
+    const ms = Date.parse('2026-06-15T12:00:00Z');
+    const out = formatDateValue(ms);
+    expect(out).toContain('2026');
+    expect(out).toContain('Jun');
+    expect(out).toContain('15');
+  });
+
+  test('formats an ISO string', () => {
+    const out = formatDateValue('2026-06-15T12:00:00Z');
+    expect(out).toContain('2026');
+    expect(out).toContain('Jun');
+    expect(out).toContain('15');
+  });
+
+  test('numeric and ISO inputs for the same instant agree', () => {
+    const iso = '2026-06-15T12:00:00Z';
+    expect(formatDateValue(Date.parse(iso))).toBe(formatDateValue(iso));
+  });
+
+  test('returns empty string for missing values', () => {
+    expect(formatDateValue(null)).toBe('');
+    expect(formatDateValue(undefined)).toBe('');
+  });
+});
+
+describe('views/detail Dates card', () => {
+  test('Created and Updated always render with formatted dates', async () => {
+    const mount = await mountIssue({
+      id: 'UI-200',
+      title: 'D',
+      status: 'open',
+      priority: 2,
+      created_at: Date.parse('2026-03-27T18:11:00Z'),
+      updated_at: Date.parse('2026-03-28T09:00:00Z')
+    });
+    const card = datesCard(mount);
+    expect(card).toBeTruthy();
+    const created = rowValue(/** @type {Element} */ (card), 'Created');
+    const updated = rowValue(/** @type {Element} */ (card), 'Updated');
+    expect(created).toContain('2026');
+    expect(created).toContain('Mar');
+    expect(created).toContain('27');
+    expect(updated).toContain('2026');
+    expect(updated).toContain('Mar');
+    expect(updated).toContain('28');
+  });
+
+  test('Started renders only when started_at present', async () => {
+    const withStart = await mountIssue({
+      id: 'UI-201',
+      title: 'D',
+      status: 'in_progress',
+      created_at: Date.parse('2026-03-27T18:11:00Z'),
+      updated_at: Date.parse('2026-03-28T09:00:00Z'),
+      started_at: '2026-03-27T20:00:00Z'
+    });
+    const card1 = /** @type {Element} */ (datesCard(withStart));
+    expect(rowValue(card1, 'Started')).toContain('Mar');
+
+    const withoutStart = await mountIssue({
+      id: 'UI-202',
+      title: 'D',
+      status: 'open',
+      created_at: Date.parse('2026-03-27T18:11:00Z'),
+      updated_at: Date.parse('2026-03-28T09:00:00Z')
+    });
+    const card2 = /** @type {Element} */ (datesCard(withoutStart));
+    expect(rowValue(card2, 'Started')).toBeNull();
+  });
+
+  test('Closed renders the date only (reason lives in Properties) and is absent when open', async () => {
+    const closed = await mountIssue({
+      id: 'UI-203',
+      title: 'D',
+      status: 'closed',
+      created_at: Date.parse('2026-03-27T18:11:00Z'),
+      updated_at: Date.parse('2026-03-28T09:00:00Z'),
+      closed_at: Date.parse('2026-03-28T10:00:00Z'),
+      close_reason: 'Done'
+    });
+    const card1 = /** @type {Element} */ (datesCard(closed));
+    const closedVal = /** @type {string} */ (rowValue(card1, 'Closed'));
+    expect(closedVal).toContain('Mar');
+    // Close reason is shown in the Properties card, not duplicated here.
+    expect(closedVal).not.toContain('Done');
+    expect(closedVal).not.toContain('—');
+
+    const open = await mountIssue({
+      id: 'UI-204',
+      title: 'D',
+      status: 'open',
+      created_at: Date.parse('2026-03-27T18:11:00Z'),
+      updated_at: Date.parse('2026-03-28T09:00:00Z')
+    });
+    const card2 = /** @type {Element} */ (datesCard(open));
+    expect(rowValue(card2, 'Closed')).toBeNull();
+  });
+
+  test('Closed without close_reason shows just the date', async () => {
+    const closed = await mountIssue({
+      id: 'UI-205',
+      title: 'D',
+      status: 'closed',
+      created_at: Date.parse('2026-03-27T18:11:00Z'),
+      updated_at: Date.parse('2026-03-28T09:00:00Z'),
+      closed_at: Date.parse('2026-03-28T10:00:00Z'),
+      close_reason: null
+    });
+    const card = /** @type {Element} */ (datesCard(closed));
+    const closedVal = /** @type {string} */ (rowValue(card, 'Closed'));
+    expect(closedVal).toContain('Mar');
+    expect(closedVal).not.toContain('—');
+  });
+
+  test('Deferred until renders only when defer_until set', async () => {
+    const deferred = await mountIssue({
+      id: 'UI-206',
+      title: 'D',
+      status: 'open',
+      created_at: Date.parse('2026-03-27T18:11:00Z'),
+      updated_at: Date.parse('2026-03-28T09:00:00Z'),
+      defer_until: '2026-04-01T12:00:00Z'
+    });
+    const card1 = /** @type {Element} */ (datesCard(deferred));
+    expect(rowValue(card1, 'Deferred until')).toContain('Apr');
+
+    const notDeferred = await mountIssue({
+      id: 'UI-207',
+      title: 'D',
+      status: 'open',
+      created_at: Date.parse('2026-03-27T18:11:00Z'),
+      updated_at: Date.parse('2026-03-28T09:00:00Z')
+    });
+    const card2 = /** @type {Element} */ (datesCard(notDeferred));
+    expect(rowValue(card2, 'Deferred until')).toBeNull();
+  });
+});

--- a/app/views/detail.js
+++ b/app/views/detail.js
@@ -33,6 +33,35 @@ function formatCommentDate(dateStr) {
 }
 
 /**
+ * Format a date value for display in the Dates card.
+ *
+ * The detail object reaches the client via `bd show --json` →
+ * `normalizeIssueList`, which overwrites `created_at`/`updated_at`/`closed_at`
+ * into numeric epoch-millisecond timestamps (via `parseTimestamp`, which uses
+ * `Date.parse`) while leaving `started_at`/`defer_until` as raw ISO strings.
+ * `new Date(value)` handles both a number(ms) and an ISO string identically.
+ *
+ * @param {number | string | null | undefined} value
+ * @returns {string} Formatted local datetime, or '' when value is missing.
+ */
+export function formatDateValue(value) {
+  if (value === null || value === undefined || value === '') return '';
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  } catch {
+    return '';
+  }
+}
+
+/**
  * @typedef {Object} Dependency
  * @property {string} id
  * @property {string} [title]
@@ -59,6 +88,11 @@ function formatCommentDate(dateStr) {
  * @property {string} [notes]
  * @property {string} [status]
  * @property {(string|null)} [close_reason]
+ * @property {(number|string)} [created_at]
+ * @property {(number|string)} [updated_at]
+ * @property {(number|string|null)} [closed_at]
+ * @property {string} [started_at]
+ * @property {string} [defer_until]
  * @property {string} [assignee]
  * @property {number} [priority]
  * @property {string[]} [labels]
@@ -1127,6 +1161,43 @@ export function createDetailView(
       </div>
     </div>`;
 
+    // Dates section block — rendered below Properties. Rows render
+    // conditionally; absent values are omitted (no blank rows).
+    // Date only — the close reason is shown in the Properties card, not
+    // duplicated here.
+    const closed_display = formatDateValue(issue.closed_at);
+    const dates_block = html`<div class="props-card dates">
+      <div class="props-card__header">
+        <div class="props-card__title">Dates</div>
+      </div>
+      <div class="prop">
+        <div class="label">Created</div>
+        <div class="value">${formatDateValue(issue.created_at)}</div>
+      </div>
+      ${issue.started_at
+        ? html`<div class="prop">
+            <div class="label">Started</div>
+            <div class="value">${formatDateValue(issue.started_at)}</div>
+          </div>`
+        : ''}
+      <div class="prop">
+        <div class="label">Updated</div>
+        <div class="value">${formatDateValue(issue.updated_at)}</div>
+      </div>
+      ${closed_display
+        ? html`<div class="prop">
+            <div class="label">Closed</div>
+            <div class="value">${closed_display}</div>
+          </div>`
+        : ''}
+      ${issue.defer_until
+        ? html`<div class="prop">
+            <div class="label">Deferred until</div>
+            <div class="value">${formatDateValue(issue.defer_until)}</div>
+          </div>`
+        : ''}
+    </div>`;
+
     // Design section block
     const design_text = String(issue.design || '');
     const design_block = edit_design
@@ -1309,6 +1380,7 @@ export function createDetailView(
                   </div>
                 </div>
               </div>
+              ${dates_block}
               ${labels_block}
               ${depsSection('Dependencies', issue.dependencies || [])}
               ${depsSection('Dependents', issue.dependents || [])}


### PR DESCRIPTION
This adds a "Dates" card to the issue detail view, below the existing Properties card. It shows when an issue was created, started, last updated, closed, and, if set, deferred until.

Each row only appears when it has a value, so open issues don't carry empty Started, Closed, or Deferred rows. The close reason already lives in the Properties card, so it isn't repeated here.

## How it works

It's a frontend-only change. bd already sends these fields to the client through `bd show --json` and `normalizeIssueList`, so there's no server or data change.

- `created_at`, `updated_at`, and `closed_at` arrive as numeric epoch-millisecond timestamps (run through `Date.parse` in `normalizeIssueList`).
- `started_at` and `defer_until` arrive as raw ISO strings.
- One `formatDateValue` helper handles both forms via `new Date(value)` and formats to a local datetime. It returns an empty string for missing values.

## Testing

Nine tests in `detail.dates.test.js` cover the formatter (both the numeric and ISO paths) and the conditional rendering of each row. Date assertions check year, month, and day rather than the hour, so they stay stable across timezones. The full `vitest` suite passes, along with `tsc`, `eslint`, and `prettier`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)