### PR TITLE
Fix detail comments after live updates

### DIFF
--- a/app/data/subscription-issue-store.js
+++ b/app/data/subscription-issue-store.js
@@ -5,6 +5,14 @@ import { debug } from '../utils/logging.js';
 import { cmpPriorityThenCreated } from './sort.js';
 
 /**
+ * @param {object} obj
+ * @param {string} key
+ */
+function hasOwn(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+/**
  * Per-subscription issue store. Holds full Issue objects and exposes a
  * deterministic, read-only snapshot for rendering. Applies snapshot/upsert/
  * delete messages in revision order and preserves object identity per id.
@@ -98,6 +106,12 @@ export function createSubscriptionIssueStore(id, options = {}) {
             ? /** @type {number} */ (it.updated_at)
             : 0;
           if (prev_ts <= next_ts) {
+            const has_incoming_comments = hasOwn(it, 'comments');
+            const preserve_comments =
+              !has_incoming_comments && hasOwn(existing, 'comments');
+            const previous_comments = preserve_comments
+              ? existing.comments
+              : undefined;
             // Mutate existing object to preserve reference
             for (const k of Object.keys(existing)) {
               if (!(k in it)) {
@@ -108,6 +122,9 @@ export function createSubscriptionIssueStore(id, options = {}) {
             for (const [k, v] of Object.entries(it)) {
               // @ts-ignore - dynamic assignment
               existing[k] = v;
+            }
+            if (preserve_comments) {
+              existing.comments = previous_comments;
             }
           } else {
             // stale by timestamp; ignore

--- a/app/data/subscription-issue-store.test.js
+++ b/app/data/subscription-issue-store.test.js
@@ -66,6 +66,82 @@ describe('subscription issue store', () => {
     expect(after).toBe(before); // identity preserved
   });
 
+  test('preserves comments when upsert omits comments', () => {
+    const store = createSubscriptionIssueStore('s1');
+    const comments = [{ id: 1, text: 'Existing comment' }];
+    store.applyPush({
+      type: 'snapshot',
+      id: 's1',
+      revision: 1,
+      issues: [
+        {
+          id: 'X',
+          title: 'x',
+          comments,
+          comment_count: 1,
+          created_at: 10_000,
+          updated_at: 10_000,
+          closed_at: null
+        }
+      ]
+    });
+
+    store.applyPush({
+      type: 'upsert',
+      id: 's1',
+      revision: 2,
+      issue: {
+        id: 'X',
+        title: 'X!',
+        comment_count: 1,
+        created_at: 10_000,
+        updated_at: 10_060,
+        closed_at: null
+      }
+    });
+
+    expect(store.getById('X')?.comments).toBe(comments);
+    expect(store.getById('X')?.title).toBe('X!');
+  });
+
+  test('accepts explicit incoming comments on upsert', () => {
+    const store = createSubscriptionIssueStore('s1');
+    store.applyPush({
+      type: 'snapshot',
+      id: 's1',
+      revision: 1,
+      issues: [
+        {
+          id: 'X',
+          title: 'x',
+          comments: [{ id: 1, text: 'Existing comment' }],
+          comment_count: 1,
+          created_at: 10_000,
+          updated_at: 10_000,
+          closed_at: null
+        }
+      ]
+    });
+
+    store.applyPush({
+      type: 'upsert',
+      id: 's1',
+      revision: 2,
+      issue: {
+        id: 'X',
+        title: 'X!',
+        comments: [],
+        comment_count: 0,
+        created_at: 10_000,
+        updated_at: 10_060,
+        closed_at: null
+      }
+    });
+
+    expect(store.getById('X')?.comments).toEqual([]);
+    expect(store.getById('X')?.comment_count).toBe(0);
+  });
+
   test('ignores stale upsert by revision and timestamp', () => {
     const store = createSubscriptionIssueStore('s1');
     store.applyPush({

--- a/app/detail.push.test.js
+++ b/app/detail.push.test.js
@@ -2,49 +2,348 @@ import { describe, expect, test } from 'vitest';
 import { createSubscriptionIssueStores } from './data/subscription-issue-stores.js';
 import { createDetailView } from './views/detail.js';
 
+function tick() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function deferred() {
+  /** @type {(value: unknown) => void} */
+  let resolve = () => {};
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * @param {number} id
+ * @param {string} text
+ * @param {string} [created_at]
+ */
+function comment(id, text, created_at = '2026-06-15T00:00:00Z') {
+  return {
+    id,
+    author: 'Fetched',
+    text,
+    created_at
+  };
+}
+
+/**
+ * @param {string} id
+ * @param {Record<string, unknown>} [fields]
+ */
+function issue(id, fields = {}) {
+  return {
+    id,
+    title: 'Original',
+    comment_count: 1,
+    created_at: 1700000000000,
+    updated_at: 1700000000000,
+    closed_at: 0,
+    ...fields
+  };
+}
+
+/**
+ * @param {any} store
+ * @param {string} id
+ * @param {Record<string, unknown>} [fields]
+ */
+function pushSnapshot(store, id, fields = {}) {
+  store.applyPush({
+    type: 'snapshot',
+    id: `detail:${id}`,
+    revision: 1,
+    issues: [issue(id, fields)]
+  });
+}
+
+/**
+ * @param {any} store
+ * @param {string} id
+ * @param {number} revision
+ * @param {Record<string, unknown>} [fields]
+ */
+function pushUpsert(store, id, revision, fields = {}) {
+  store.applyPush({
+    type: 'upsert',
+    id: `detail:${id}`,
+    revision,
+    issue: issue(id, {
+      updated_at: 1700000000000 + revision * 1000,
+      ...fields
+    })
+  });
+}
+
+/**
+ * @param {string} id
+ * @param {(type: string, payload?: unknown) => Promise<unknown>} sendFn
+ */
+async function setupDetail(id, sendFn) {
+  document.body.innerHTML = '<section id="mount"></section>';
+  const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+  const issueStores = createSubscriptionIssueStores();
+  const view = createDetailView(
+    mount,
+    sendFn,
+    (hash) => (window.location.hash = hash),
+    issueStores
+  );
+
+  await view.load(id);
+  issueStores.register(`detail:${id}`, {
+    type: 'issue-detail',
+    params: { id }
+  });
+  const store = issueStores.getStore(`detail:${id}`);
+  expect(store).not.toBeNull();
+  return {
+    mount,
+    store: /** @type {NonNullable<typeof store>} */ (store),
+    view,
+    issueStores
+  };
+}
+
 describe('detail view via subscription push', () => {
   test('renders snapshot from detail:<id> store', async () => {
-    document.body.innerHTML = '<section id="mount"></section>';
-    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
-
-    const issueStores = createSubscriptionIssueStores();
-    const view = createDetailView(
-      mount,
-      // sendFn not used for load in push mode
-      async () => ({}),
-      (hash) => (window.location.hash = hash),
-      issueStores
-    );
-
-    await view.load('UI-1');
-
-    // Register store and push a snapshot for detail subscription
-    issueStores.register('detail:UI-1', {
-      type: 'issue-detail',
-      params: { id: 'UI-1' }
-    });
-
-    const store = issueStores.getStore('detail:UI-1');
-    expect(store).not.toBeNull();
-    store?.applyPush({
-      type: 'snapshot',
-      id: 'detail:UI-1',
-      revision: 1,
-      issues: [
-        {
-          id: 'UI-1',
-          title: 'A title',
-          status: 'open',
-          priority: 2,
-          created_at: 1700000000000,
-          updated_at: 1700000000000,
-          closed_at: 0
-        }
-      ]
+    const { mount, store } = await setupDetail('UI-1', async () => ({}));
+    pushSnapshot(store, 'UI-1', {
+      title: 'A title',
+      status: 'open',
+      priority: 2
     });
 
     // Expect title to appear in the detail view
     const h2 = mount.querySelector('#detail-root h2');
     expect(h2?.textContent || '').toContain('A title');
+  });
+
+  test('fetches comments after delayed detail snapshot arrives', async () => {
+    /** @type {Array<{type: string, payload: unknown}>} */
+    const calls = [];
+
+    const { mount, store } = await setupDetail(
+      'UI-2',
+      async (type, payload) => {
+        calls.push({ type, payload });
+        if (type === 'get-comments') {
+          return [comment(1, 'Fetched comment')];
+        }
+        return {};
+      }
+    );
+
+    pushSnapshot(store, 'UI-2', {
+      title: 'Delayed title'
+    });
+    await tick();
+
+    expect(calls).toEqual([{ type: 'get-comments', payload: { id: 'UI-2' } }]);
+    expect(mount.querySelectorAll('.comment-item').length).toBe(1);
+    expect(mount.textContent).toContain('Fetched comment');
+  });
+
+  test('keeps comments after later detail update omits comments', async () => {
+    let fetch_count = 0;
+
+    const { mount, store } = await setupDetail('UI-3', async (type) => {
+      if (type === 'get-comments') {
+        fetch_count += 1;
+        return [comment(1, 'Persistent comment')];
+      }
+      return {};
+    });
+
+    pushSnapshot(store, 'UI-3');
+    await tick();
+
+    pushUpsert(store, 'UI-3', 2, {
+      title: 'Updated'
+    });
+    await tick();
+
+    expect(fetch_count).toBe(1);
+    expect(mount.textContent).toContain('Updated');
+    expect(mount.textContent).toContain('Persistent comment');
+  });
+
+  test('refetches comments when comment count changes', async () => {
+    let fetch_count = 0;
+
+    const { mount, store } = await setupDetail('UI-4', async (type) => {
+      if (type === 'get-comments') {
+        fetch_count += 1;
+        return fetch_count === 1
+          ? [comment(1, 'First comment')]
+          : [
+              comment(1, 'First comment'),
+              comment(2, 'Second comment', '2026-06-15T00:01:00Z')
+            ];
+      }
+      return {};
+    });
+
+    pushSnapshot(store, 'UI-4');
+    await tick();
+
+    pushUpsert(store, 'UI-4', 2, {
+      title: 'Updated',
+      comment_count: 2
+    });
+    await tick();
+
+    expect(fetch_count).toBe(2);
+    expect(mount.querySelectorAll('.comment-item').length).toBe(2);
+    expect(mount.textContent).toContain('Second comment');
+  });
+
+  test('keeps comments until count-matching refetch succeeds', async () => {
+    let fetch_count = 0;
+
+    const { mount, store } = await setupDetail('UI-4B', async (type) => {
+      if (type === 'get-comments') {
+        fetch_count += 1;
+        if (fetch_count === 1) {
+          return [comment(1, 'Original comment')];
+        }
+        if (fetch_count === 2) {
+          return [comment(1, 'Incomplete replacement')];
+        }
+        return [
+          comment(1, 'Original comment'),
+          comment(2, 'Complete replacement', '2026-06-15T00:01:00Z')
+        ];
+      }
+      return {};
+    });
+
+    pushSnapshot(store, 'UI-4B');
+    await tick();
+
+    pushUpsert(store, 'UI-4B', 2, {
+      title: 'Count changed',
+      comment_count: 2
+    });
+    await tick();
+
+    expect(fetch_count).toBe(2);
+    expect(mount.textContent).toContain('Original comment');
+    expect(mount.textContent).not.toContain('Incomplete replacement');
+
+    pushUpsert(store, 'UI-4B', 3, {
+      title: 'Count still changed',
+      comment_count: 2
+    });
+    await tick();
+
+    expect(fetch_count).toBe(3);
+    expect(mount.textContent).toContain('Complete replacement');
+  });
+
+  test('retries comments after failed fetch clears in-flight state', async () => {
+    let fetch_count = 0;
+
+    const { mount, store } = await setupDetail('UI-5', async (type) => {
+      if (type === 'get-comments') {
+        fetch_count += 1;
+        if (fetch_count === 1) {
+          throw new Error('temporary failure');
+        }
+        return [comment(1, 'Recovered comment')];
+      }
+      return {};
+    });
+
+    pushSnapshot(store, 'UI-5');
+    await tick();
+
+    pushUpsert(store, 'UI-5', 2, {
+      title: 'Retry'
+    });
+    await tick();
+
+    expect(fetch_count).toBe(2);
+    expect(mount.textContent).toContain('Recovered comment');
+  });
+
+  test('retries comments after non-array response', async () => {
+    let fetch_count = 0;
+
+    const { mount, store } = await setupDetail('UI-5B', async (type) => {
+      if (type === 'get-comments') {
+        fetch_count += 1;
+        if (fetch_count === 1) {
+          return { error: 'not ready' };
+        }
+        return [comment(1, 'Recovered array comment')];
+      }
+      return {};
+    });
+
+    pushSnapshot(store, 'UI-5B');
+    await tick();
+
+    pushUpsert(store, 'UI-5B', 2, {
+      title: 'Retry'
+    });
+    await tick();
+
+    expect(fetch_count).toBe(2);
+    expect(mount.textContent).toContain('Recovered array comment');
+  });
+
+  test('discards stale comment response after issue switch', async () => {
+    const slow = deferred();
+
+    const { mount, view, issueStores } = await setupDetail(
+      'UI-6A',
+      async (type, payload) => {
+        if (type === 'get-comments') {
+          const id = /** @type {{ id: string }} */ (payload).id;
+          if (id === 'UI-6A') {
+            return slow.promise;
+          }
+          return [comment(2, 'Active issue comment', '2026-06-15T00:01:00Z')];
+        }
+        return {};
+      }
+    );
+
+    const store_a = issueStores.getStore('detail:UI-6A');
+    expect(store_a).not.toBeNull();
+    pushSnapshot(
+      /** @type {NonNullable<typeof store_a>} */ (store_a),
+      'UI-6A',
+      {
+        title: 'Slow issue'
+      }
+    );
+    await tick();
+
+    await view.load('UI-6B');
+    issueStores.register('detail:UI-6B', {
+      type: 'issue-detail',
+      params: { id: 'UI-6B' }
+    });
+    const store_b = issueStores.getStore('detail:UI-6B');
+    expect(store_b).not.toBeNull();
+    pushSnapshot(
+      /** @type {NonNullable<typeof store_b>} */ (store_b),
+      'UI-6B',
+      {
+        title: 'Active issue'
+      }
+    );
+    await tick();
+
+    slow.resolve([comment(1, 'Stale issue comment')]);
+    await tick();
+
+    expect(mount.textContent).toContain('Active issue');
+    expect(mount.textContent).toContain('Active issue comment');
+    expect(mount.textContent).not.toContain('Stale issue comment');
   });
 });

--- a/app/views/detail.js
+++ b/app/views/detail.js
@@ -114,6 +114,10 @@ export function createDetailView(
   let comment_text = '';
   /** @type {boolean} */
   let comment_pending = false;
+  /** @type {Set<string>} */
+  const comments_loading = new Set();
+  /** @type {Map<string, number>} */
+  const comments_loaded_counts = new Map();
 
   /** @type {HTMLDialogElement | null} */
   let delete_dialog = null;
@@ -252,12 +256,103 @@ export function createDetailView(
     }
   }
 
+  /**
+   * @param {IssueDetail} issue
+   */
+  function issueCommentCount(issue) {
+    const count = Number(/** @type {any} */ (issue).comment_count);
+    return Number.isFinite(count) && count >= 0 ? count : null;
+  }
+
+  /**
+   * @param {IssueDetail} issue
+   */
+  function hasCurrentComments(issue) {
+    const comments = /** @type {any} */ (issue).comments;
+    if (!Array.isArray(comments)) {
+      return false;
+    }
+    const count = issueCommentCount(issue);
+    if (count === null) {
+      return true;
+    }
+    const id = String(issue.id);
+    return (
+      comments.length === count || comments_loaded_counts.get(id) === count
+    );
+  }
+
+  /**
+   * @param {IssueDetail} issue
+   * @param {Comment[]} comments
+   * @param {boolean} for_current_count
+   */
+  function markCommentsLoaded(issue, comments, for_current_count) {
+    const id = String(issue.id);
+    const count = issueCommentCount(issue);
+    comments_loaded_counts.set(
+      id,
+      count !== null && for_current_count ? count : comments.length
+    );
+  }
+
+  /**
+   * Fetch comments for the selected issue once the detail subscription has
+   * arrived. This enriches the current store issue object; the subscription
+   * store preserves that field until the server explicitly sends comments.
+   *
+   * @param {string | null} id
+   */
+  async function ensureCommentsLoaded(id) {
+    const issue_id = id ? String(id) : '';
+    if (
+      !issue_id ||
+      current_id !== issue_id ||
+      !current ||
+      String(current.id) !== issue_id ||
+      hasCurrentComments(current) ||
+      comments_loading.has(issue_id)
+    ) {
+      return;
+    }
+    comments_loading.add(issue_id);
+    try {
+      const comments = await sendFn('get-comments', { id: issue_id });
+      if (
+        Array.isArray(comments) &&
+        current &&
+        current_id === issue_id &&
+        String(current.id) === issue_id
+      ) {
+        const count = issueCommentCount(current);
+        if (count !== null && comments.length !== count) {
+          comments_loaded_counts.set(issue_id, comments.length);
+          log(
+            'comment count mismatch for %s: expected %d, got %d',
+            issue_id,
+            count,
+            comments.length
+          );
+          return;
+        }
+        /** @type {any} */ (current).comments = comments;
+        markCommentsLoaded(current, comments, true);
+        doRender();
+      }
+    } catch (err) {
+      log('fetch comments failed %s %o', issue_id, err);
+    } finally {
+      comments_loading.delete(issue_id);
+    }
+  }
+
   // Live updates: re-render when issue stores change
   if (issue_stores && typeof issue_stores.subscribe === 'function') {
     issue_stores.subscribe(() => {
       try {
         refreshFromStore();
         doRender();
+        void ensureCommentsLoaded(current_id);
       } catch (err) {
         log('issue stores listener error %o', err);
       }
@@ -839,6 +934,7 @@ export function createDetailView(
       if (Array.isArray(result)) {
         // Update comments in current issue
         /** @type {any} */ (current).comments = result;
+        markCommentsLoaded(current, result, false);
         comment_text = '';
         doRender();
       }
@@ -1502,18 +1598,7 @@ export function createDetailView(
       comment_pending = false;
       doRender();
 
-      // Fetch comments if not already present
-      if (current && !(/** @type {any} */ (current).comments)) {
-        try {
-          const comments = await sendFn('get-comments', { id: current_id });
-          if (Array.isArray(comments) && current && current_id === id) {
-            /** @type {any} */ (current).comments = comments;
-            doRender();
-          }
-        } catch (err) {
-          log('fetch comments failed %s %o', id, err);
-        }
-      }
+      await ensureCommentsLoaded(current_id);
     },
     clear() {
       renderPlaceholder('Select an issue to view details');

--- a/types/subscriptions.ts
+++ b/types/subscriptions.ts
@@ -20,6 +20,8 @@ export interface Issue extends IssueRef {
   issue_type?: string;
   assignee?: string | null;
   labels?: string[];
+  comment_count?: number;
+  comments?: Array<Record<string, unknown>>;
   // Relationship fields for detail payloads
   dependencies?: DependencyRef[];
   dependents?: DependencyRef[];


### PR DESCRIPTION
## Summary

- Preserve fetched issue comments when subscription upserts omit `comments`
- Load comments after delayed detail snapshots and refetch when `comment_count` changes
- Add regression coverage for delayed snapshots, omitted comments, count mismatches, malformed responses, failed fetches, and stale issue switches

## Root cause

The detail view enriches issue objects with comments from `get-comments`, but later subscription updates can omit `comments`. When those updates replaced the current issue state, the comments section rendered as empty even though comments had already loaded.

## Validation

- `npm run prettier:check`
- `npm run tsc`
- `npm run lint`
- `npm test -- app/data/subscription-issue-store.test.js app/detail.push.test.js app/views/detail.test.js`
- `npm test`
- `npm run build`