### PR TITLE
fix(detail): request --include-dependents so children render

### DIFF
--- a/server/list-adapters.js
+++ b/server/list-adapters.js
@@ -45,7 +45,7 @@ export function mapSubscriptionToBdArgs(spec) {
       if (id.length === 0) {
         throw badRequest('Missing param: params.id');
       }
-      return ['show', id, '--json'];
+      return ['show', id, '--json', '--include-dependents'];
     }
     default: {
       throw badRequest(`Unknown subscription type: ${t}`);

--- a/server/list-adapters.test.js
+++ b/server/list-adapters.test.js
@@ -62,7 +62,7 @@ describe('list adapters for subscription types', () => {
       type: 'issue-detail',
       params: { id: 'UI-123' }
     });
-    expect(args).toEqual(['show', 'UI-123', '--json']);
+    expect(args).toEqual(['show', 'UI-123', '--json', '--include-dependents']);
   });
 
   test('fetchListForSubscription returns normalized items (Date.parse)', async () => {


### PR DESCRIPTION
Fixes #93.

## Problem
The issue/epic detail view never shows children or dependents, even when present.

## Cause
The `issue-detail` subscription adapter runs `bd show <id> --json`, which returns `dependent_count` but **no** `dependents` array. The detail view renders children from `epic.dependents[]` (`selectEpicChildren`), so it has nothing to show. bd only streams the array when asked:

```
bd show <id> --json                       # no dependents key
bd show <id> --json --include-dependents  # dependents: [ {id, dependency_type, status, title}, ... ]
```

## Fix
Add `--include-dependents` to the `issue-detail` adapter command (one line), and update the colocated unit test assertion.

## Verification
- `server/list-adapters.test.js` passes (11/11).
- Manually verified against bd 1.0.5: an epic with 11 `parent-child` children rendered all of them in the detail view after this change + server restart. Works for `parent-child`, `child-of`, and `blocks` relationships alike.

## Note
bd warns `--include-dependents` "may be slow on hub beads" with very many dependents. Negligible for typical epics; a hub-bead guard could be a follow-up if it ever matters.

(15 unrelated tests fail on a pristine checkout of `main` in my environment; this change neither causes nor fixes those.)