### PR TITLE
 feat(server): honor XDG Base Directory for registry location

### DIFF
--- a/server/registry-watcher.js
+++ b/server/registry-watcher.js
@@ -7,7 +7,7 @@ const log = debug('registry-watcher');
 
 /**
  * In-memory registry of workspaces registered dynamically via the API.
- * These supplement the file-based registry at ~/.beads/registry.json.
+ * These supplement the file-based registry (see {@link getRegistryPath}).
  *
  * @type {Map<string, { path: string, database: string, pid: number, version: string }>}
  */
@@ -50,12 +50,39 @@ export function getInMemoryWorkspaces() {
  */
 
 /**
- * Get the path to the global beads registry file.
+ * Resolve the path to the global beads registry file, honoring the XDG Base
+ * Directory specification while staying backward compatible with the legacy
+ * `~/.beads` location, according to precedence:
  *
+ * 1) `$BEADS_REGISTRY_DIR/registry.json` (explicit override)
+ * 2) `~/.beads/registry.json` when that legacy file already exists
+ * 3) `$XDG_DATA_HOME/beads/registry.json` when `XDG_DATA_HOME` is absolute
+ * 4) `~/.local/share/beads/registry.json` (XDG default)
+ *
+ * Existing setups are never silently migrated: the legacy `~/.beads` path keeps
+ * winning whenever it is already present. Per the XDG Base Directory spec, a
+ * relative (or empty) `XDG_DATA_HOME` is ignored and the default is used.
+ *
+ * @param {{ env?: Record<string, string | undefined> }} [options]
  * @returns {string}
  */
-export function getRegistryPath() {
-  return path.join(os.homedir(), '.beads', 'registry.json');
+export function getRegistryPath({ env = process.env } = {}) {
+  const override = env.BEADS_REGISTRY_DIR;
+  if (override && override.length > 0) {
+    return path.join(path.resolve(override), 'registry.json');
+  }
+
+  const legacy = path.join(os.homedir(), '.beads', 'registry.json');
+  if (fs.existsSync(legacy)) {
+    return legacy;
+  }
+
+  const xdg_data_home = env.XDG_DATA_HOME;
+  const data_home =
+    xdg_data_home && path.isAbsolute(xdg_data_home)
+      ? xdg_data_home
+      : path.join(os.homedir(), '.local', 'share');
+  return path.join(data_home, 'beads', 'registry.json');
 }
 
 /**

--- a/server/registry-watcher.test.js
+++ b/server/registry-watcher.test.js
@@ -1,0 +1,88 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { getRegistryPath } from './registry-watcher.js';
+
+/** @type {string[]} */
+const tmps = [];
+
+function mkdtemp() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'beads-ui-test-'));
+  tmps.push(dir);
+  return dir;
+}
+
+/**
+ * @param {string} home
+ */
+function writeLegacyRegistry(home) {
+  fs.mkdirSync(path.join(home, '.beads'));
+  fs.writeFileSync(path.join(home, '.beads', 'registry.json'), '[]');
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const d of tmps.splice(0)) {
+    try {
+      fs.rmSync(d, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+});
+
+describe('getRegistryPath', () => {
+  test('override wins over an existing legacy registry and XDG_DATA_HOME', () => {
+    const home = mkdtemp();
+    writeLegacyRegistry(home);
+    vi.spyOn(os, 'homedir').mockReturnValue(home);
+
+    const result = getRegistryPath({
+      env: { BEADS_REGISTRY_DIR: '/custom/dir', XDG_DATA_HOME: '/data' }
+    });
+
+    expect(result).toBe(path.join('/custom/dir', 'registry.json'));
+  });
+
+  test('prefers legacy ~/.beads over XDG_DATA_HOME when it exists', () => {
+    const home = mkdtemp();
+    writeLegacyRegistry(home);
+    vi.spyOn(os, 'homedir').mockReturnValue(home);
+
+    const result = getRegistryPath({ env: { XDG_DATA_HOME: '/data' } });
+
+    expect(result).toBe(path.join(home, '.beads', 'registry.json'));
+  });
+
+  test('uses XDG_DATA_HOME when set and no legacy registry exists', () => {
+    const home = mkdtemp();
+    vi.spyOn(os, 'homedir').mockReturnValue(home);
+
+    const result = getRegistryPath({ env: { XDG_DATA_HOME: '/data' } });
+
+    expect(result).toBe(path.join('/data', 'beads', 'registry.json'));
+  });
+
+  test('ignores a relative XDG_DATA_HOME and falls back to ~/.local/share', () => {
+    const home = mkdtemp();
+    vi.spyOn(os, 'homedir').mockReturnValue(home);
+
+    const result = getRegistryPath({ env: { XDG_DATA_HOME: 'relative/dir' } });
+
+    expect(result).toBe(
+      path.join(home, '.local', 'share', 'beads', 'registry.json')
+    );
+  });
+
+  test('falls back to ~/.local/share/beads without env or legacy', () => {
+    const home = mkdtemp();
+    vi.spyOn(os, 'homedir').mockReturnValue(home);
+
+    const result = getRegistryPath({ env: {} });
+
+    expect(result).toBe(
+      path.join(home, '.local', 'share', 'beads', 'registry.json')
+    );
+  });
+});


### PR DESCRIPTION
beads-ui's workspace registry is hardcoded to `~/.beads/registry.json` with no way to relocate it, so it pollutes `$HOME` even when application state is kept elsewhere. `bd` lets you move its shared server with `BEADS_SHARED_SERVER_DIR`; beads-ui's registry has no equivalent knob.

`getRegistryPath()` now resolves with precedence:

1. `$BEADS_REGISTRY_DIR/registry.json` — explicit override
2. `~/.beads/registry.json` — when it already exists (back-compat; never silently migrated)
3. `$XDG_DATA_HOME/beads/registry.json` — when `XDG_DATA_HOME` is absolute
4. `~/.local/share/beads/registry.json` — XDG default

Because legacy `~/.beads` wins whenever present, this is safe regardless of where the registry file's writer puts it. Per the XDG spec, a relative or empty `XDG_DATA_HOME` is ignored. The resolver takes an injectable env for testing, mirroring `resolveDbPath()` in `db.js`.