### PR TITLE
Pass --include-dependents in issue-detail adapter so epic children render

### DIFF
--- a/server/list-adapters.js
+++ b/server/list-adapters.js
@@ -45,7 +45,7 @@ export function mapSubscriptionToBdArgs(spec) {
       if (id.length === 0) {
         throw badRequest('Missing param: params.id');
       }
-      return ['show', id, '--json'];
+      return ['show', id, '--json', '--include-dependents'];
     }
     default: {
       throw badRequest(`Unknown subscription type: ${t}`);

--- a/server/list-adapters.test.js
+++ b/server/list-adapters.test.js
@@ -62,7 +62,7 @@ describe('list adapters for subscription types', () => {
       type: 'issue-detail',
       params: { id: 'UI-123' }
     });
-    expect(args).toEqual(['show', 'UI-123', '--json']);
+    expect(args).toEqual(['show', 'UI-123', '--json', '--include-dependents']);
   });
 
   test('fetchListForSubscription returns normalized items (Date.parse)', async () => {


### PR DESCRIPTION
## Summary

- Add `--include-dependents` flag to the `bd show` call in the `issue-detail` adapter
- Update the corresponding test expectation to cover the flag
- No other files changed (minimal one-line fix)

## Why

When opening an epic in beads-ui, the Epics view renders `epic.dependents` to list
child issues and show a progress bar. However, the server-side `issue-detail` adapter
was calling `bd show <id> --json` **without** `--include-dependents`.

bd 1.0.5 behaviour:
- Without the flag: response contains only `dependent_count` — the `dependents` array is omitted entirely.
- With the flag: response contains the full `dependents` array.

Because `epic.dependents` is `undefined` (not an empty array), `selectEpicChildren`
always returns zero children, and the UI shows "No issues found" even when children
exist.

## What

`server/list-adapters.js` — `issue-detail` case (one-line change):

```diff
-      return ['show', id, '--json'];
+      return ['show', id, '--json', '--include-dependents'];
```

`server/list-adapters.test.js` — updated expected args to include the new flag.

## How

Straightforward flag addition to the existing arg array. No new logic, no new
dependencies, no formatting changes.

## Verification

Verified against bd 1.0.5 with a Dolt-backed aggregation workspace (~800 issues):

- `bd show <epic-id> --json` (without flag): returns `dependent_count: 25`, `dependents` key absent
- `bd show <epic-id> --json --include-dependents`: returns `dependents` array with 25 entries in 0.33 s
- After this patch: Epics view expands and renders all child issues correctly

Test results (`npm test`): **65 test files, 272 tests — all passed**

RED → GREEN cycle for the modified test:
- Before fix: `mapSubscriptionToBdArgs returns args for issue-detail` failed (received `['show', 'UI-123', '--json']`, expected `[..., '--include-dependents']`)
- After fix: all 11 tests in `server/list-adapters.test.js` pass

**Note:** This overlaps with PR #94 — happy to close this one if #94 is preferred;
this PR adds the measured verification context from a live bd 1.0.5 + Dolt deployment.

## Test plan

- [x] [auto] `npx vitest run server/list-adapters.test.js` — 11/11 pass; `mapSubscriptionToBdArgs returns args for issue-detail` transitions RED→GREEN with the fix
- [x] [auto] `npm test` — 65 test files, 272 tests, 0 failures
- [x] [auto] `npx prettier --check server/list-adapters.js server/list-adapters.test.js` — "All matched files use Prettier code style!"
- [x] [one-shot-e2e] Live bd 1.0.5 + Dolt workspace smoke test: confirmed `bd show <epic> --json --include-dependents` returns 25 dependents in 0.33 s; Epics view renders children after patch (1 run, no re-run needed — environment-specific external dependency)
- [ ] [manual] Upstream maintainer review: confirm compatibility with bd versions prior to 1.0.5
