### PR TITLE
fix: use 'bd comments add' so --author is accepted

### DIFF
--- a/server/ws.comments.test.js
+++ b/server/ws.comments.test.js
@@ -153,7 +153,8 @@ describe('add-comment handler', () => {
 
     // Verify bd was called with correct args including --author
     expect(rb).toHaveBeenCalledWith([
-      'comment',
+      'comments',
+      'add',
       'UI-1',
       'New comment',
       '--author',
@@ -190,7 +191,12 @@ describe('add-comment handler', () => {
     expect(reply.ok).toBe(true);
 
     // Verify bd was called without --author
-    expect(rb).toHaveBeenCalledWith(['comment', 'UI-1', 'Anonymous comment']);
+    expect(rb).toHaveBeenCalledWith([
+      'comments',
+      'add',
+      'UI-1',
+      'Anonymous comment'
+    ]);
   });
 
   test('returns error when text is empty', async () => {

--- a/server/ws.js
+++ b/server/ws.js
@@ -1199,7 +1199,7 @@ export async function handleMessage(ws, data) {
 
     // Get git user name for author attribution
     const author = await getGitUserName();
-    const args = ['comment', id, text.trim()];
+    const args = ['comments', 'add', id, text.trim()];
     if (author) {
       args.push('--author', author);
     }


### PR DESCRIPTION
Fixes #67
Fixes #74

## The bug

Adding a comment from the UI fails for anyone with a git `user.name` configured (the common case), and the failure is silent — the form clears but the comment never persists.

The `add-comment` handler shells out to `bd` with the **`comment` shorthand** and appends `--author <name>` when a git user name is set:

```js
const args = ['comment', id, text.trim()];
if (author) {
  args.push('--author', author);
}
```

But the `bd comment` shorthand does not accept `--author` — only the full `bd comments add` subcommand does. So the invocation fails whenever an author is appended.

## The fix

Switch the invocation from the `comment` shorthand to the `comments add` subcommand, which accepts `-a/--author`:

```js
const args = ['comments', 'add', id, text.trim()];
```

One source line, plus the two handler-test assertions that were asserting the broken `['comment', ...]` argv (they passed only because `runBd` is mocked).

## Why this is the broadly-compatible form (test plan)

I checked the `bd` source at the exact versions the two issue reporters run, plus the current line. `bd comments add --author` has existed continuously and works on all of them; the shorthand path fails on all of them:

| bd version | `bd comment` shorthand | `--author` on shorthand | `bd comments add --author` | UI today | This fix |
|---|:-:|:-:|:-:|:-:|:-:|
| 0.59.0 (#67) | not present yet | — | yes | fails (unknown command) | works |
| 0.63.3 (#74) | present | no | yes | fails (unknown flag) | works |
| 1.0.0–1.0.5 | present | no | yes | fails (unknown flag) | works |

So this is not a latest-version-only adaptation — it is the form that works across the whole supported range, and it resolves both open reports on the exact versions those users are on.

As a bonus, `bd comments add` already defaults the author to the git user name when `--author` is omitted, so attribution is preserved either way.

## Checks

`npm run lint`, `npm run tsc`, `npm run prettier:check`, and the `add-comment` handler tests all pass locally.
