### PR TITLE
fix(list): pass --limit 0 so bd list isn't truncated at its default 50 rows

### DIFF
--- a/server/list-adapters.js
+++ b/server/list-adapters.js
@@ -14,7 +14,8 @@ export function mapSubscriptionToBdArgs(spec) {
   const t = String(spec.type);
   switch (t) {
     case 'all-issues': {
-      return ['list', '--json', '--tree=false'];
+      // `--limit 0` = unlimited. Without it, `bd list` caps at its default 50.
+      return ['list', '--json', '--tree=false', '--limit', '0'];
     }
     case 'epics': {
       return ['epic', 'status', '--json'];
@@ -26,7 +27,16 @@ export function mapSubscriptionToBdArgs(spec) {
       return ['ready', '--limit', '1000', '--json'];
     }
     case 'in-progress-issues': {
-      return ['list', '--json', '--tree=false', '--status', 'in_progress'];
+      // `--limit 0` = unlimited. Without it, `bd list` caps at its default 50.
+      return [
+        'list',
+        '--json',
+        '--tree=false',
+        '--status',
+        'in_progress',
+        '--limit',
+        '0'
+      ];
     }
     case 'closed-issues': {
       return [

--- a/server/list-adapters.test.js
+++ b/server/list-adapters.test.js
@@ -14,7 +14,8 @@ describe('list adapters for subscription types', () => {
 
   test('mapSubscriptionToBdArgs returns args for all-issues', () => {
     const args = mapSubscriptionToBdArgs({ type: 'all-issues' });
-    expect(args).toEqual(['list', '--json', '--tree=false']);
+    // `--limit 0` = unlimited; without it bd list truncates at its default 50
+    expect(args).toEqual(['list', '--json', '--tree=false', '--limit', '0']);
   });
 
   test('mapSubscriptionToBdArgs returns args for epics', () => {
@@ -35,12 +36,15 @@ describe('list adapters for subscription types', () => {
 
   test('mapSubscriptionToBdArgs returns args for in-progress-issues', () => {
     const args = mapSubscriptionToBdArgs({ type: 'in-progress-issues' });
+    // `--limit 0` = unlimited; without it bd list truncates at its default 50
     expect(args).toEqual([
       'list',
       '--json',
       '--tree=false',
       '--status',
-      'in_progress'
+      'in_progress',
+      '--limit',
+      '0'
     ]);
   });
 


### PR DESCRIPTION
`bd list` defaults to `--limit 50`. Two of the subscriptions in `mapSubscriptionToBdArgs` build their `bd list` call without a `--limit` flag, so they quietly stop at 50 rows and the UI never knows there's more.

I hit this on a workspace with 68 issues. The Issues tab showed 50. The missing 18 were the low-priority tail, because bd sorts by priority and the cut takes the bottom off the list. Nothing in the UI indicates a limit was applied, so the list just looks complete.

The fix is to pass `--limit 0`, which bd documents as unlimited:

```
-n, --limit int   Limit results (default 50, use 0 for unlimited)
```

Two cases needed it. `all-issues` backs the Issues tab and is the one that actually bites. `in-progress-issues` has the same omission, latent until you have more than 50 issues in progress at once.

I left the rest alone. `ready-issues` and `closed-issues` already pass an explicit `--limit 1000`, and `blocked` and `epic status` take no `--limit` flag at all. The tests now assert those bounds as well, so a later refactor can't silently unbound them or re-introduce a cap.

Worth deciding separately: a user-selectable row limit seems like a reasonable feature, but any limit wants a visible "showing N of M" affordance. Silent capping is what caused this in the first place.

`npm run all` is green: 281 tests, plus eslint, tsc and prettier.
