### PR TITLE
feat(status): support all seven bd statuses (depends on #99)

### DIFF
--- a/app/data/list-selectors.js
+++ b/app/data/list-selectors.js
@@ -4,7 +4,10 @@
  * triggers once per issues envelope to let views re-render.
  */
 /**
- * @typedef {{ id: string, title?: string, status?: 'open'|'in_progress'|'closed', priority?: number, issue_type?: string, created_at?: number, updated_at?: number, closed_at?: number }} IssueLite
+ * @import { Status } from '../protocol.js'
+ */
+/**
+ * @typedef {{ id: string, title?: string, status?: Status, priority?: number, issue_type?: string, created_at?: number, updated_at?: number, closed_at?: number }} IssueLite
  */
 import { cmpClosedDesc, cmpPriorityThenCreated } from './sort.js';
 

--- a/app/data/list-selectors.js
+++ b/app/data/list-selectors.js
@@ -62,6 +62,45 @@ export function createListSelectors(issue_stores = undefined) {
   }
 
   /**
+   * Get entities for a Board column fed by more than one subscription.
+   *
+   * The Blocked lane is the union of `bd blocked` (dependency-blocked issues,
+   * whose own status is `open`) and `bd list --status blocked` (issues whose
+   * stored status is `blocked`). The two sources overlap, so entries are
+   * deduplicated by id — first occurrence wins — before sorting.
+   *
+   * @param {string[]} client_ids
+   * @param {'ready'|'blocked'|'in_progress'|'closed'} mode
+   * @returns {IssueLite[]}
+   */
+  function selectBoardColumnUnion(client_ids, mode) {
+    if (!issue_stores || typeof issue_stores.snapshotFor !== 'function') {
+      return [];
+    }
+    /** @type {IssueLite[]} */
+    const merged = [];
+    /** @type {Set<string>} */
+    const seen = new Set();
+    for (const client_id of Array.isArray(client_ids) ? client_ids : []) {
+      for (const it of issue_stores.snapshotFor(client_id) || []) {
+        const id = String(it?.id ?? '');
+        if (id.length === 0 || seen.has(id)) {
+          continue;
+        }
+        seen.add(id);
+        merged.push(it);
+      }
+    }
+    if (mode === 'closed') {
+      merged.sort(cmpClosedDesc);
+    } else {
+      // ready/blocked/in_progress share the same sort
+      merged.sort(cmpPriorityThenCreated);
+    }
+    return merged;
+  }
+
+  /**
    * Get children for an epic subscribed as client id `epic:${id}`.
    * Sorted as Issues List (priority asc → created asc).
    *
@@ -100,6 +139,7 @@ export function createListSelectors(issue_stores = undefined) {
   return {
     selectIssuesFor,
     selectBoardColumn,
+    selectBoardColumnUnion,
     selectEpicChildren,
     subscribe
   };

--- a/app/data/list-selectors.test.js
+++ b/app/data/list-selectors.test.js
@@ -209,6 +209,71 @@ describe('list-selectors', () => {
     expect(out).toEqual(['E2', 'E1']);
   });
 
+  test('selectBoardColumnUnion merges sources, dedupes by id and sorts', async () => {
+    const { issueStores, selectors } = setup();
+    issueStores.getStore('tab:board:blocked').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:blocked',
+      revision: 1,
+      issues: [
+        {
+          id: 'D1',
+          priority: 2,
+          created_at: 10_000,
+          updated_at: 10_000,
+          closed_at: null
+        },
+        {
+          id: 'BOTH',
+          priority: 0,
+          created_at: 12_000,
+          updated_at: 12_000,
+          closed_at: null
+        }
+      ]
+    });
+    issueStores.getStore('tab:board:status-blocked').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:status-blocked',
+      revision: 1,
+      issues: [
+        {
+          id: 'BOTH',
+          priority: 0,
+          created_at: 12_000,
+          updated_at: 12_000,
+          closed_at: null
+        },
+        {
+          id: 'S1',
+          priority: 1,
+          created_at: 9_000,
+          updated_at: 9_000,
+          closed_at: null
+        }
+      ]
+    });
+
+    const ids = selectors
+      .selectBoardColumnUnion(
+        ['tab:board:blocked', 'tab:board:status-blocked'],
+        'blocked'
+      )
+      .map((x) => x.id);
+    // Deduped (BOTH appears once) and sorted priority asc → created asc
+    expect(ids).toEqual(['BOTH', 'S1', 'D1']);
+  });
+
+  test('selectBoardColumnUnion returns empty for unknown client ids', async () => {
+    const { selectors } = setup();
+    expect(
+      selectors.selectBoardColumnUnion(
+        ['tab:board:blocked', 'tab:board:status-blocked'],
+        'blocked'
+      )
+    ).toEqual([]);
+  });
+
   test('subscribe triggers once per issues envelope', async () => {
     const { issueStores, selectors } = setup();
     let calls = 0;

--- a/app/data/providers.js
+++ b/app/data/providers.js
@@ -1,5 +1,5 @@
 /**
- * @import { MessageType } from '../protocol.js'
+ * @import { MessageType, SettableStatus } from '../protocol.js'
  */
 import { debug } from '../utils/logging.js';
 
@@ -9,7 +9,7 @@ import { debug } from '../utils/logging.js';
  * stores and selectors (see docs/adr/001-push-only-lists.md).
  *
  * @param {(type: MessageType, payload?: unknown) => Promise<unknown>} transport - Request/response function.
- * @returns {{ updateIssue: (input: { id: string, title?: string, acceptance?: string, notes?: string, design?: string, status?: 'open'|'in_progress'|'closed', priority?: number, assignee?: string, issue_type?: string }) => Promise<unknown> }}
+ * @returns {{ updateIssue: (input: { id: string, title?: string, acceptance?: string, notes?: string, design?: string, status?: SettableStatus, priority?: number, assignee?: string, issue_type?: string }) => Promise<unknown> }}
  */
 export function createDataLayer(transport) {
   const log = debug('data');
@@ -18,7 +18,7 @@ export function createDataLayer(transport) {
    * Supported fields: title, acceptance, notes, design, status, priority, assignee, issue_type.
    * Returns the updated issue on success.
    *
-   * @param {{ id: string, title?: string, acceptance?: string, notes?: string, design?: string, status?: 'open'|'in_progress'|'closed', priority?: number, assignee?: string, issue_type?: string }} input
+   * @param {{ id: string, title?: string, acceptance?: string, notes?: string, design?: string, status?: SettableStatus, priority?: number, assignee?: string, issue_type?: string }} input
    * @returns {Promise<unknown>}
    */
   async function updateIssue(input) {

--- a/app/data/sort.js
+++ b/app/data/sort.js
@@ -4,7 +4,11 @@
  */
 
 /**
- * @typedef {{ id: string, title?: string, status?: 'open'|'in_progress'|'closed', priority?: number, issue_type?: string, created_at?: number, updated_at?: number, closed_at?: number }} IssueLite
+ * @import { Status } from '../protocol.js'
+ */
+
+/**
+ * @typedef {{ id: string, title?: string, status?: Status, priority?: number, issue_type?: string, created_at?: number, updated_at?: number, closed_at?: number }} IssueLite
  */
 
 /**

--- a/app/main.filters-persistence.test.js
+++ b/app/main.filters-persistence.test.js
@@ -245,7 +245,7 @@ describe('issues view — status filter persistence', () => {
 
     await reload();
 
-    expect(selectedScopeLabel()).toBe('All issues');
+    expect(selectedScopeLabel()).toBe('By status');
     expect(checkedStatusLabels()).toEqual(['Open']);
     expect(lastIssuesSpecType()).toBe('all-issues');
     expect(rowIds()).toEqual(['A-1']);
@@ -272,7 +272,7 @@ describe('issues view — status filter persistence', () => {
     await reload();
 
     expect(checkedStatusLabels()).toEqual([]);
-    expect(selectedScopeLabel()).toBe('All issues');
+    expect(selectedScopeLabel()).toBe('By status');
     expect(rowIds()).toEqual(['A-1', 'B-1', 'C-1']);
   });
 

--- a/app/main.filters-persistence.test.js
+++ b/app/main.filters-persistence.test.js
@@ -1,0 +1,302 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { bootstrap } from './main.js';
+import { createWsClient } from './ws.js';
+
+/**
+ * Click the status checkbox with the given label in the status dropdown.
+ *
+ * @param {string} label - Visible label of the checkbox.
+ */
+function toggleStatus(label) {
+  const dropdown = document.querySelectorAll('.filter-dropdown')[0];
+  const trigger = /** @type {HTMLButtonElement} */ (
+    dropdown.querySelector('.filter-dropdown__trigger')
+  );
+  trigger.click();
+  const option = Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--status')
+  ).find((opt) => (opt.textContent || '').trim() === label);
+  const checkbox = /** @type {HTMLInputElement} */ (
+    option?.querySelector('input[type="checkbox"]')
+  );
+  checkbox.click();
+}
+
+/**
+ * Labels of the status checkboxes that are currently checked.
+ *
+ * @returns {string[]}
+ */
+function checkedStatusLabels() {
+  const dropdown = document.querySelectorAll('.filter-dropdown')[0];
+  return Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--status')
+  )
+    .filter((opt) => {
+      const box = /** @type {HTMLInputElement|null} */ (
+        opt.querySelector('input[type="checkbox"]')
+      );
+      return Boolean(box && box.checked);
+    })
+    .map((opt) => (opt.textContent || '').trim());
+}
+
+/**
+ * The label of the selected scope radio.
+ *
+ * @returns {string}
+ */
+function selectedScopeLabel() {
+  const dropdown = document.querySelectorAll('.filter-dropdown')[0];
+  const option = Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--scope')
+  ).find((opt) => {
+    const radio = /** @type {HTMLInputElement|null} */ (
+      opt.querySelector('input[type="radio"]')
+    );
+    return Boolean(radio && radio.checked);
+  });
+  return option ? (option.textContent || '').trim() : '';
+}
+
+/**
+ * The persisted status filter as stored in localStorage.
+ *
+ * @returns {unknown}
+ */
+function storedStatusFilter() {
+  const raw = window.localStorage.getItem('beads-ui.filters');
+  return raw ? JSON.parse(raw).status : undefined;
+}
+
+/**
+ * The spec type of the most recent `tab:issues` subscription request.
+ *
+ * @returns {string}
+ */
+function lastIssuesSpecType() {
+  const subs = calls.filter(
+    (c) => c.type === 'subscribe-list' && c.payload?.id === 'tab:issues'
+  );
+  return subs.length > 0 ? String(subs[subs.length - 1].payload.type) : '';
+}
+
+/**
+ * Ids of the currently rendered rows.
+ *
+ * @returns {string[]}
+ */
+function rowIds() {
+  return Array.from(document.querySelectorAll('#list-root tr.issue-row')).map(
+    (el) => el.getAttribute('data-issue-id') || ''
+  );
+}
+
+/**
+ * Let queued microtasks (subscriptions, store notifications) settle.
+ */
+async function settle() {
+  for (let i = 0; i < 6; i++) {
+    await Promise.resolve();
+  }
+}
+
+const ALL_ISSUES = [
+  {
+    id: 'A-1',
+    title: 'open one',
+    status: 'open',
+    created_at: 10,
+    updated_at: 10
+  },
+  {
+    id: 'B-1',
+    title: 'blocked one',
+    status: 'blocked',
+    created_at: 20,
+    updated_at: 20
+  },
+  {
+    id: 'C-1',
+    title: 'in progress one',
+    status: 'in_progress',
+    created_at: 30,
+    updated_at: 30
+  }
+];
+
+// Mock WS client to drive push envelopes and record RPCs
+/** @type {{ type: string, payload: any }[]} */
+const calls = [];
+vi.mock('./ws.js', () => {
+  /** @type {Record<string, (p: any) => void>} */
+  const handlers = {};
+  const singleton = {
+    /**
+     * @param {import('./protocol.js').MessageType} type
+     * @param {any} payload
+     */
+    async send(type, payload) {
+      calls.push({ type, payload });
+      return null;
+    },
+    /**
+     * @param {import('./protocol.js').MessageType} type
+     * @param {(p: any) => void} handler
+     */
+    on(type, handler) {
+      handlers[type] = handler;
+      return () => {
+        delete handlers[type];
+      };
+    },
+    /**
+     * Test helper: trigger a server event.
+     *
+     * @param {import('./protocol.js').MessageType} type
+     * @param {any} payload
+     */
+    _trigger(type, payload) {
+      if (handlers[type]) {
+        handlers[type](payload);
+      }
+    },
+    onConnection() {
+      return () => {};
+    },
+    close() {},
+    getState() {
+      return 'open';
+    }
+  };
+  return { createWsClient: () => singleton };
+});
+
+/**
+ * Boot the app into a fresh DOM, keeping localStorage — a page reload.
+ *
+ * @returns {Promise<any>} The mock ws client.
+ */
+async function reload() {
+  calls.length = 0;
+  const client = /** @type {any} */ (createWsClient());
+  window.location.hash = '#/issues';
+  document.body.innerHTML = '<main id="app"></main>';
+  const root = /** @type {HTMLElement} */ (document.getElementById('app'));
+
+  bootstrap(root);
+  await settle();
+  client._trigger('snapshot', {
+    type: 'snapshot',
+    id: 'tab:issues',
+    revision: 1,
+    issues: ALL_ISSUES
+  });
+  await settle();
+  return client;
+}
+
+describe('issues view — status filter persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('persists a multi-status selection as an array', async () => {
+    await reload();
+
+    toggleStatus('Open');
+    await settle();
+    toggleStatus('Blocked');
+    await settle();
+
+    expect(storedStatusFilter()).toEqual(['open', 'blocked']);
+  });
+
+  test('restores a multi-status selection after a reload', async () => {
+    await reload();
+    toggleStatus('Open');
+    await settle();
+    toggleStatus('Blocked');
+    await settle();
+
+    await reload();
+
+    expect(checkedStatusLabels()).toEqual(['Open', 'Blocked']);
+    expect(rowIds()).toEqual(['A-1', 'B-1']);
+  });
+
+  test('restores the Ready scope after a reload', async () => {
+    window.localStorage.setItem(
+      'beads-ui.filters',
+      JSON.stringify({ status: ['ready'], search: '', type: '' })
+    );
+
+    await reload();
+
+    expect(selectedScopeLabel()).toBe('Ready only');
+    expect(lastIssuesSpecType()).toBe('ready-issues');
+  });
+
+  test('resolves a stored ready + status mix to the status', async () => {
+    window.localStorage.setItem(
+      'beads-ui.filters',
+      JSON.stringify({ status: ['ready', 'open'], search: '', type: '' })
+    );
+
+    await reload();
+
+    expect(selectedScopeLabel()).toBe('All issues');
+    expect(checkedStatusLabels()).toEqual(['Open']);
+    expect(lastIssuesSpecType()).toBe('all-issues');
+    expect(rowIds()).toEqual(['A-1']);
+  });
+
+  test('migrates a legacy scalar status to an array', async () => {
+    window.localStorage.setItem(
+      'beads-ui.filters',
+      JSON.stringify({ status: 'open', search: '', type: '' })
+    );
+
+    await reload();
+
+    expect(checkedStatusLabels()).toEqual(['Open']);
+    expect(rowIds()).toEqual(['A-1']);
+  });
+
+  test('migrates the legacy scalar "all" to an empty selection', async () => {
+    window.localStorage.setItem(
+      'beads-ui.filters',
+      JSON.stringify({ status: 'all', search: '', type: '' })
+    );
+
+    await reload();
+
+    expect(checkedStatusLabels()).toEqual([]);
+    expect(selectedScopeLabel()).toBe('All issues');
+    expect(rowIds()).toEqual(['A-1', 'B-1', 'C-1']);
+  });
+
+  test('drops unknown members of a stored selection', async () => {
+    window.localStorage.setItem(
+      'beads-ui.filters',
+      JSON.stringify({ status: ['bogus', 'blocked'], search: '', type: '' })
+    );
+
+    await reload();
+
+    expect(checkedStatusLabels()).toEqual(['Blocked']);
+    expect(rowIds()).toEqual(['B-1']);
+  });
+
+  test('falls back to an empty selection for an invalid stored value', async () => {
+    window.localStorage.setItem(
+      'beads-ui.filters',
+      JSON.stringify({ status: 42, search: '', type: '' })
+    );
+
+    await reload();
+
+    expect(checkedStatusLabels()).toEqual([]);
+    expect(rowIds()).toEqual(['A-1', 'B-1', 'C-1']);
+  });
+});

--- a/app/main.issues-fast-filters.test.js
+++ b/app/main.issues-fast-filters.test.js
@@ -138,7 +138,7 @@ describe('issues view — fast filter switching', () => {
     selectScope('Ready only');
     // ready -> in_progress (fast); the Ready scope disables the status
     // checkboxes, so leaving it is part of the switch
-    selectScope('All issues');
+    selectScope('By status');
     toggleFilter(0, 'In progress');
     // Allow store subscriptions and sub_issue_stores.register to run
     await Promise.resolve();

--- a/app/main.issues-fast-filters.test.js
+++ b/app/main.issues-fast-filters.test.js
@@ -26,6 +26,26 @@ function toggleFilter(dropdownIndex, optionText) {
   checkbox.click();
 }
 
+/**
+ * Helper to pick a scope radio in the status dropdown.
+ *
+ * @param {string} label - Visible label of the radio
+ */
+function selectScope(label) {
+  const dropdown = document.querySelectorAll('.filter-dropdown')[0];
+  const trigger = /** @type {HTMLButtonElement} */ (
+    dropdown.querySelector('.filter-dropdown__trigger')
+  );
+  trigger.click();
+  const option = Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--scope')
+  ).find((opt) => (opt.textContent || '').trim() === label);
+  const radio = /** @type {HTMLInputElement} */ (
+    option?.querySelector('input[type="radio"]')
+  );
+  radio.click();
+}
+
 // Mock WS client to drive push envelopes and record RPCs
 /** @type {{ type: string, payload: any }[]} */
 const calls = [];
@@ -115,8 +135,10 @@ describe('issues view — fast filter switching', () => {
 
     // Quickly toggle status: all -> ready -> in_progress before any server data
     // all -> ready
-    toggleFilter(0, 'Ready');
-    // ready -> in_progress (fast)
+    selectScope('Ready only');
+    // ready -> in_progress (fast); the Ready scope disables the status
+    // checkboxes, so leaving it is part of the switch
+    selectScope('All issues');
     toggleFilter(0, 'In progress');
     // Allow store subscriptions and sub_issue_stores.register to run
     await Promise.resolve();

--- a/app/main.js
+++ b/app/main.js
@@ -1,5 +1,6 @@
 /**
  * @import { MessageType } from './protocol.js'
+ * @import { StatusFilter } from './state.js'
  */
 import { html, render } from 'lit-html';
 import { createListSelectors } from './data/list-selectors.js';
@@ -10,6 +11,7 @@ import { createHashRouter, parseHash, parseView } from './router.js';
 import { createStore } from './state.js';
 import { createActivityIndicator } from './utils/activity-indicator.js';
 import { debug } from './utils/logging.js';
+import { STATUSES } from './utils/status.js';
 import { showToast } from './utils/toast.js';
 import { createBoardView } from './views/board.js';
 import { createDetailView } from './views/detail.js';
@@ -345,7 +347,7 @@ export function bootstrap(root_element) {
       client.onConnection(onConn);
     }
     // Load persisted filters (status/search/type) from localStorage
-    /** @type {{ status: 'all'|'open'|'in_progress'|'closed'|'ready', search: string, type: string }} */
+    /** @type {{ status: StatusFilter, search: string, type: string }} */
     let persisted_filters = { status: 'all', search: '', type: '' };
     try {
       const raw = window.localStorage.getItem('beads-ui.filters');
@@ -368,9 +370,7 @@ export function bootstrap(root_element) {
             parsed_type = first_valid;
           }
           persisted_filters = {
-            status: ['all', 'open', 'in_progress', 'closed', 'ready'].includes(
-              obj.status
-            )
+            status: ['all', 'ready', ...STATUSES].includes(obj.status)
               ? obj.status
               : 'all',
             search: typeof obj.search === 'string' ? obj.search : '',

--- a/app/main.js
+++ b/app/main.js
@@ -1,6 +1,6 @@
 /**
  * @import { MessageType } from './protocol.js'
- * @import { StatusFilter } from './state.js'
+ * @import { StatusFilter } from './utils/status.js'
  */
 import { html, render } from 'lit-html';
 import { createListSelectors } from './data/list-selectors.js';
@@ -11,7 +11,7 @@ import { createHashRouter, parseHash, parseView } from './router.js';
 import { createStore } from './state.js';
 import { createActivityIndicator } from './utils/activity-indicator.js';
 import { debug } from './utils/logging.js';
-import { STATUSES } from './utils/status.js';
+import { normalizeStatusFilters } from './utils/status.js';
 import { showToast } from './utils/toast.js';
 import { createBoardView } from './views/board.js';
 import { createDetailView } from './views/detail.js';
@@ -347,8 +347,8 @@ export function bootstrap(root_element) {
       client.onConnection(onConn);
     }
     // Load persisted filters (status/search/type) from localStorage
-    /** @type {{ status: StatusFilter, search: string, type: string }} */
-    let persisted_filters = { status: 'all', search: '', type: '' };
+    /** @type {{ status: StatusFilter[], search: string, type: string }} */
+    let persisted_filters = { status: [], search: '', type: '' };
     try {
       const raw = window.localStorage.getItem('beads-ui.filters');
       if (raw) {
@@ -370,9 +370,9 @@ export function bootstrap(root_element) {
             parsed_type = first_valid;
           }
           persisted_filters = {
-            status: ['all', 'ready', ...STATUSES].includes(obj.status)
-              ? obj.status
-              : 'all',
+            // Tolerates the legacy scalar form and drops unknown members; an
+            // entirely invalid value degrades to "all issues".
+            status: normalizeStatusFilters(obj.status),
             search: typeof obj.search === 'string' ? obj.search : '',
             type: parsed_type
           };
@@ -498,7 +498,7 @@ export function bootstrap(root_element) {
     // Persist filter changes to localStorage
     store.subscribe((s) => {
       const data = {
-        status: s.filters.status,
+        status: normalizeStatusFilters(s.filters.status),
         search: s.filters.search,
         type: typeof s.filters.type === 'string' ? s.filters.type : ''
       };
@@ -674,21 +674,28 @@ export function bootstrap(root_element) {
     /**
      * Compute subscription spec for Issues tab based on filters.
      *
-     * @param {{ status?: string }} filters
+     * A lone selection can be served by a dedicated server-side list; a union
+     * of several statuses cannot, so it falls back to all-issues and lets the
+     * list view narrow the rows client-side.
+     *
+     * @param {{ status?: unknown }} filters
      * @returns {{ type: string, params?: Record<string, string|number|boolean> }}
      */
     function computeIssuesSpec(filters) {
-      const st = String(filters?.status || 'all');
-      if (st === 'ready') {
-        return { type: 'ready-issues' };
+      const selected = normalizeStatusFilters(filters?.status);
+      if (selected.length === 1) {
+        if (selected[0] === 'ready') {
+          return { type: 'ready-issues' };
+        }
+        if (selected[0] === 'in_progress') {
+          return { type: 'in-progress-issues' };
+        }
+        if (selected[0] === 'closed') {
+          return { type: 'closed-issues' };
+        }
       }
-      if (st === 'in_progress') {
-        return { type: 'in-progress-issues' };
-      }
-      if (st === 'closed') {
-        return { type: 'closed-issues' };
-      }
-      // "all" and "open" map to all-issues; client filters apply locally
+      // No selection, a status without a dedicated list (e.g. open), or a
+      // union of several: fetch everything and filter locally.
       return { type: 'all-issues' };
     }
 

--- a/app/main.js
+++ b/app/main.js
@@ -183,6 +183,10 @@ export function bootstrap(root_element) {
         void unsub_board_blocked().catch(() => {});
         unsub_board_blocked = null;
       }
+      if (unsub_board_status_blocked) {
+        void unsub_board_status_blocked().catch(() => {});
+        unsub_board_status_blocked = null;
+      }
       // Clear all subscription stores
       const storeIds = [
         'tab:issues',
@@ -190,7 +194,8 @@ export function bootstrap(root_element) {
         'tab:board:ready',
         'tab:board:in-progress',
         'tab:board:closed',
-        'tab:board:blocked'
+        'tab:board:blocked',
+        'tab:board:status-blocked'
       ];
       for (const id of storeIds) {
         try {
@@ -658,6 +663,8 @@ export function bootstrap(root_element) {
     let unsub_board_closed = null;
     /** @type {null | (() => Promise<void>)} */
     let unsub_board_blocked = null;
+    /** @type {null | (() => Promise<void>)} */
+    let unsub_board_status_blocked = null;
 
     // Track in-flight subscriptions to prevent duplicates during rapid view switching
     /** @type {Set<string>} */
@@ -883,6 +890,34 @@ export function bootstrap(root_element) {
               pending_subscriptions.delete('tab:board:blocked');
             });
         }
+        // Blocked column, second source: issues whose stored status is
+        // `blocked`. `bd blocked` reports only dependency-blocked issues, so
+        // without this subscription those issues appear in no lane at all.
+        if (
+          !unsub_board_status_blocked &&
+          !pending_subscriptions.has('tab:board:status-blocked')
+        ) {
+          try {
+            sub_issue_stores.register('tab:board:status-blocked', {
+              type: 'status-blocked-issues'
+            });
+          } catch (err) {
+            log('register board:status-blocked store failed: %o', err);
+          }
+          pending_subscriptions.add('tab:board:status-blocked');
+          void subscriptions
+            .subscribeList('tab:board:status-blocked', {
+              type: 'status-blocked-issues'
+            })
+            .then((u) => (unsub_board_status_blocked = u))
+            .catch((err) => {
+              log('subscribe board status-blocked failed: %o', err);
+              showFatalFromError(err, 'board (Blocked)');
+            })
+            .finally(() => {
+              pending_subscriptions.delete('tab:board:status-blocked');
+            });
+        }
       } else {
         // Unsubscribe all board lists when leaving the board view
         if (unsub_board_ready) {
@@ -919,6 +954,15 @@ export function bootstrap(root_element) {
             sub_issue_stores.unregister('tab:board:blocked');
           } catch (err) {
             log('unregister board:blocked failed: %o', err);
+          }
+        }
+        if (unsub_board_status_blocked) {
+          void unsub_board_status_blocked().catch(() => {});
+          unsub_board_status_blocked = null;
+          try {
+            sub_issue_stores.unregister('tab:board:status-blocked');
+          } catch (err) {
+            log('unregister board:status-blocked failed: %o', err);
           }
         }
       }

--- a/app/main.push-stores.e2e.test.js
+++ b/app/main.push-stores.e2e.test.js
@@ -8,15 +8,19 @@ vi.mock('./ws.js', () => {
   const handlers = {};
   /** @type {Set<(s: 'connecting'|'open'|'closed'|'reconnecting') => void>} */
   const connHandlers = new Set();
+  /** @type {Array<[string, any]>} */
+  const sent = [];
   const singleton = {
+    /** Test helper: every message the client was asked to send */
+    _sent: sent,
     /**
      * @param {import('./protocol.js').MessageType} type
      * @param {any} payload
      */
     async send(type, payload) {
-      // Subscriptions are fire-and-forget in tests
-      void type;
-      void payload;
+      // Subscriptions are fire-and-forget in tests, but recorded so tests can
+      // assert which subscriptions a view requests.
+      sent.push([String(type), payload]);
       return null;
     },
     /**
@@ -184,5 +188,67 @@ describe('push stores integration (board view)', () => {
     });
     await Promise.resolve();
     expect(document.querySelectorAll('#ready-col .board-card').length).toBe(2);
+  });
+
+  test('subscribes to both blocked sources when the board is shown', async () => {
+    const client = /** @type {any} */ (createWsClient());
+    client._sent.length = 0;
+    window.location.hash = '#/board';
+    document.body.innerHTML = '<main id="app"></main>';
+    const root = /** @type {HTMLElement} */ (document.getElementById('app'));
+
+    bootstrap(root);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const requested = client._sent
+      .filter((/** @type {[string, any]} */ e) => e[0] === 'subscribe-list')
+      .map((/** @type {[string, any]} */ e) => e[1]);
+    expect(
+      requested.find((/** @type {any} */ p) => p.id === 'tab:board:blocked')
+        ?.type
+    ).toBe('blocked-issues');
+    expect(
+      requested.find(
+        (/** @type {any} */ p) => p.id === 'tab:board:status-blocked'
+      )?.type
+    ).toBe('status-blocked-issues');
+  });
+
+  test('renders both blocked sources into the Blocked column, deduped', async () => {
+    const client = /** @type {any} */ (createWsClient());
+    window.location.hash = '#/board';
+    document.body.innerHTML = '<main id="app"></main>';
+    const root = /** @type {HTMLElement} */ (document.getElementById('app'));
+
+    bootstrap(root);
+    await Promise.resolve();
+
+    // Dependency-blocked (from `bd blocked`; own status is open)
+    client._trigger('snapshot', {
+      type: 'snapshot',
+      id: 'tab:board:blocked',
+      revision: 1,
+      issues: [
+        { id: 'D-1', title: 'dep blocked', priority: 1, updated_at: 10_000 },
+        { id: 'X-1', title: 'both', priority: 1, updated_at: 10_100 }
+      ]
+    });
+    // Stored-status blocked (from `bd list --status blocked`)
+    client._trigger('snapshot', {
+      type: 'snapshot',
+      id: 'tab:board:status-blocked',
+      revision: 1,
+      issues: [
+        { id: 'S-1', title: 'status blocked', priority: 1, updated_at: 10_200 },
+        { id: 'X-1', title: 'both', priority: 1, updated_at: 10_100 }
+      ]
+    });
+    await Promise.resolve();
+
+    const ids = Array.from(
+      document.querySelectorAll('#blocked-col .board-card')
+    ).map((el) => el.getAttribute('data-issue-id'));
+    expect(ids.slice().sort()).toEqual(['D-1', 'S-1', 'X-1']);
   });
 });

--- a/app/main.status-filter.test.js
+++ b/app/main.status-filter.test.js
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { bootstrap } from './main.js';
+import { createWsClient } from './ws.js';
+
+/**
+ * Click the scope radio with the given label in the status dropdown.
+ *
+ * @param {string} label - Visible label of the radio.
+ */
+function selectScope(label) {
+  const dropdown = document.querySelectorAll('.filter-dropdown')[0];
+  const trigger = /** @type {HTMLButtonElement} */ (
+    dropdown.querySelector('.filter-dropdown__trigger')
+  );
+  trigger.click();
+  const option = Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--scope')
+  ).find((opt) => (opt.textContent || '').trim() === label);
+  const radio = /** @type {HTMLInputElement} */ (
+    option?.querySelector('input[type="radio"]')
+  );
+  radio.click();
+}
+
+/**
+ * Click the status checkbox with the given label in the status dropdown.
+ *
+ * @param {string} label - Visible label of the checkbox.
+ */
+function toggleStatus(label) {
+  const dropdown = document.querySelectorAll('.filter-dropdown')[0];
+  const trigger = /** @type {HTMLButtonElement} */ (
+    dropdown.querySelector('.filter-dropdown__trigger')
+  );
+  trigger.click();
+  const option = Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--status')
+  ).find((opt) => (opt.textContent || '').trim() === label);
+  const checkbox = /** @type {HTMLInputElement} */ (
+    option?.querySelector('input[type="checkbox"]')
+  );
+  checkbox.click();
+}
+
+/**
+ * The spec type of the most recent `tab:issues` subscription request.
+ *
+ * @returns {string}
+ */
+function lastIssuesSpecType() {
+  const subs = calls.filter(
+    (c) => c.type === 'subscribe-list' && c.payload?.id === 'tab:issues'
+  );
+  return subs.length > 0 ? String(subs[subs.length - 1].payload.type) : '';
+}
+
+/**
+ * Ids of the currently rendered rows.
+ *
+ * @returns {string[]}
+ */
+function rowIds() {
+  return Array.from(document.querySelectorAll('#list-root tr.issue-row')).map(
+    (el) => el.getAttribute('data-issue-id') || ''
+  );
+}
+
+/**
+ * Let queued microtasks (subscriptions, store notifications) settle.
+ */
+async function settle() {
+  for (let i = 0; i < 6; i++) {
+    await Promise.resolve();
+  }
+}
+
+const ALL_ISSUES = [
+  {
+    id: 'A-1',
+    title: 'open one',
+    status: 'open',
+    created_at: 10,
+    updated_at: 10
+  },
+  {
+    id: 'B-1',
+    title: 'blocked one',
+    status: 'blocked',
+    created_at: 20,
+    updated_at: 20
+  },
+  {
+    id: 'C-1',
+    title: 'in progress one',
+    status: 'in_progress',
+    created_at: 30,
+    updated_at: 30
+  }
+];
+
+// Mock WS client to drive push envelopes and record RPCs
+/** @type {{ type: string, payload: any }[]} */
+const calls = [];
+vi.mock('./ws.js', () => {
+  /** @type {Record<string, (p: any) => void>} */
+  const handlers = {};
+  const singleton = {
+    /**
+     * @param {import('./protocol.js').MessageType} type
+     * @param {any} payload
+     */
+    async send(type, payload) {
+      calls.push({ type, payload });
+      return null;
+    },
+    /**
+     * @param {import('./protocol.js').MessageType} type
+     * @param {(p: any) => void} handler
+     */
+    on(type, handler) {
+      handlers[type] = handler;
+      return () => {
+        delete handlers[type];
+      };
+    },
+    /**
+     * Test helper: trigger a server event.
+     *
+     * @param {import('./protocol.js').MessageType} type
+     * @param {any} payload
+     */
+    _trigger(type, payload) {
+      if (handlers[type]) {
+        handlers[type](payload);
+      }
+    },
+    onConnection() {
+      return () => {};
+    },
+    close() {},
+    getState() {
+      return 'open';
+    }
+  };
+  return { createWsClient: () => singleton };
+});
+
+describe('issues view — status filter model', () => {
+  /** @type {any} */
+  let client;
+
+  beforeEach(async () => {
+    calls.length = 0;
+    window.localStorage.clear();
+    client = /** @type {any} */ (createWsClient());
+    window.location.hash = '#/issues';
+    document.body.innerHTML = '<main id="app"></main>';
+    const root = /** @type {HTMLElement} */ (document.getElementById('app'));
+
+    bootstrap(root);
+    await settle();
+    client._trigger('snapshot', {
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: ALL_ISSUES
+    });
+    await settle();
+  });
+
+  test('leaving the Ready scope for a status narrows to that status', async () => {
+    selectScope('Ready only');
+    await settle();
+
+    selectScope('All issues');
+    await settle();
+    toggleStatus('Open');
+    await settle();
+
+    expect(lastIssuesSpecType()).toBe('all-issues');
+    client._trigger('snapshot', {
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 2,
+      issues: ALL_ISSUES
+    });
+    await settle();
+    expect(rowIds()).toEqual(['A-1']);
+  });
+
+  test('selecting Ready after a status subscribes to ready issues', async () => {
+    toggleStatus('Open');
+    await settle();
+
+    selectScope('Ready only');
+    await settle();
+
+    expect(lastIssuesSpecType()).toBe('ready-issues');
+    client._trigger('snapshot', {
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 2,
+      issues: [ALL_ISSUES[2]]
+    });
+    await settle();
+    expect(rowIds()).toEqual(['C-1']);
+  });
+
+  test('two statuses subscribe to all issues and filter client-side', async () => {
+    toggleStatus('Open');
+    await settle();
+    toggleStatus('Blocked');
+    await settle();
+
+    expect(lastIssuesSpecType()).toBe('all-issues');
+    client._trigger('snapshot', {
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 2,
+      issues: ALL_ISSUES
+    });
+    await settle();
+    expect(rowIds()).toEqual(['A-1', 'B-1']);
+  });
+
+  test('a single stored status keeps its dedicated subscription', async () => {
+    toggleStatus('In progress');
+    await settle();
+
+    expect(lastIssuesSpecType()).toBe('in-progress-issues');
+  });
+
+  test('in progress plus another status widens to all issues', async () => {
+    toggleStatus('In progress');
+    await settle();
+    toggleStatus('Blocked');
+    await settle();
+
+    expect(lastIssuesSpecType()).toBe('all-issues');
+  });
+
+  test('fast toggles settle on the subscription of the final selection', async () => {
+    // No awaits in between: both toggles land before any subscription resolves.
+    toggleStatus('In progress');
+    selectScope('Ready only');
+    await settle();
+
+    expect(lastIssuesSpecType()).toBe('ready-issues');
+
+    // Newer revision for the ready list arrives first…
+    client._trigger('snapshot', {
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 3,
+      issues: [ALL_ISSUES[0], ALL_ISSUES[2]]
+    });
+    await settle();
+    // …then a stale snapshot of the abandoned list, which must not win.
+    client._trigger('snapshot', {
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 2,
+      issues: [ALL_ISSUES[2]]
+    });
+    await settle();
+
+    expect(rowIds()).toEqual(['A-1', 'C-1']);
+  });
+
+  test('fast toggles back out of the Ready scope keep the last selection', async () => {
+    selectScope('Ready only');
+    selectScope('All issues');
+    toggleStatus('In progress');
+    await settle();
+
+    expect(lastIssuesSpecType()).toBe('in-progress-issues');
+
+    client._trigger('snapshot', {
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 3,
+      issues: [ALL_ISSUES[2]]
+    });
+    await settle();
+    client._trigger('snapshot', {
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 2,
+      issues: ALL_ISSUES
+    });
+    await settle();
+
+    expect(rowIds()).toEqual(['C-1']);
+  });
+});

--- a/app/main.status-filter.test.js
+++ b/app/main.status-filter.test.js
@@ -172,7 +172,7 @@ describe('issues view — status filter model', () => {
     selectScope('Ready only');
     await settle();
 
-    selectScope('All issues');
+    selectScope('By status');
     await settle();
     toggleStatus('Open');
     await settle();
@@ -269,7 +269,7 @@ describe('issues view — status filter model', () => {
 
   test('fast toggles back out of the Ready scope keep the last selection', async () => {
     selectScope('Ready only');
-    selectScope('All issues');
+    selectScope('By status');
     toggleStatus('In progress');
     await settle();
 

--- a/app/protocol.js
+++ b/app/protocol.js
@@ -12,6 +12,63 @@
 /** @typedef {'list-issues'|'update-status'|'edit-text'|'update-priority'|'update-type'|'create-issue'|'list-ready'|'dep-add'|'dep-remove'|'epic-status'|'update-assignee'|'label-add'|'label-remove'|'subscribe-list'|'unsubscribe-list'|'snapshot'|'upsert'|'delete'|'get-comments'|'add-comment'|'delete-issue'|'list-workspaces'|'set-workspace'|'get-workspace'|'workspace-changed'} MessageType */
 
 /**
+ * Every status `bd` can report on an issue.
+ *
+ * @typedef {'open'|'in_progress'|'blocked'|'deferred'|'closed'|'pinned'|'hooked'} Status
+ */
+
+/**
+ * The subset of {@link Status} a human may set. `pinned` and `hooked` are
+ * owned by bd's own machinery (list pinning, gate/formula workflow engine), so
+ * the UI renders them but never offers them as an edit, and `update-status`
+ * rejects them.
+ *
+ * @typedef {'open'|'in_progress'|'blocked'|'deferred'|'closed'} SettableStatus
+ */
+
+/**
+ * All statuses, in canonical order.
+ *
+ * @type {readonly Status[]}
+ */
+export const STATUSES = [
+  'open',
+  'in_progress',
+  'blocked',
+  'deferred',
+  'closed',
+  'pinned',
+  'hooked'
+];
+
+/**
+ * Statuses a human may set, in canonical order. Shared by the client (the
+ * status `<select>`s) and the server (`update-status` validation) so the two
+ * cannot drift.
+ *
+ * @type {readonly SettableStatus[]}
+ */
+export const SETTABLE_STATUSES = [
+  'open',
+  'in_progress',
+  'blocked',
+  'deferred',
+  'closed'
+];
+
+/**
+ * Whether an arbitrary string is a status a human may set. The single gate for
+ * both the client (which options a `<select>` offers) and the server (which
+ * `update-status` payloads it accepts).
+ *
+ * @param {string} status
+ * @returns {status is SettableStatus}
+ */
+export function isSettableStatus(status) {
+  return /** @type {readonly string[]} */ (SETTABLE_STATUSES).includes(status);
+}
+
+/**
  * @typedef {Object} RequestEnvelope
  * @property {string} id - Unique id to correlate request/response.
  * @property {MessageType} type - Message type.

--- a/app/protocol.md
+++ b/app/protocol.md
@@ -29,7 +29,8 @@ a generated `id`.
 
 - Removed in v2: `list-issues` (use subscriptions + push stores)
 - `update-status` payload:
-  `{ id: string, status: 'open'|'in_progress'|'closed' }`
+  `{ id: string, status: 'open'|'in_progress'|'blocked'|'deferred'|'closed' }`
+  (bd's `pinned` and `hooked` statuses are machine-managed and rejected here)
 - `edit-text` payload:
   `{ id: string, field: 'title'|'description'|'acceptance'|'notes'|'design', value: string }`
 - `update-priority` payload: `{ id: string, priority: 0|1|2|3|4 }`

--- a/app/state.js
+++ b/app/state.js
@@ -4,7 +4,14 @@
 import { debug } from './utils/logging.js';
 
 /**
- * @typedef {'all'|'open'|'in_progress'|'closed'|'ready'} StatusFilter
+ * @import { Status } from './protocol.js'
+ */
+
+/**
+ * A status filter is any status bd can report, plus the derived `ready`
+ * selection and the `all` default.
+ *
+ * @typedef {'all'|'ready'|Status} StatusFilter
  */
 
 /**

--- a/app/state.js
+++ b/app/state.js
@@ -2,20 +2,18 @@
  * Minimal app state store with subscription.
  */
 import { debug } from './utils/logging.js';
+import { normalizeStatusFilters, sameStatusFilters } from './utils/status.js';
 
 /**
- * @import { Status } from './protocol.js'
+ * @import { StatusFilter } from './utils/status.js'
  */
 
 /**
- * A status filter is any status bd can report, plus the derived `ready`
- * selection and the `all` default.
+ * The status filter is a selection, not a single value: either exactly
+ * `['ready']` or a subset of the stored statuses. An empty selection means
+ * "all issues".
  *
- * @typedef {'all'|'ready'|Status} StatusFilter
- */
-
-/**
- * @typedef {{ status: StatusFilter, search: string, type: string }} Filters
+ * @typedef {{ status: StatusFilter[], search: string, type: string }} Filters
  */
 
 /**
@@ -61,7 +59,7 @@ export function createStore(initial = {}) {
     selected_id: initial.selected_id ?? null,
     view: initial.view ?? 'issues',
     filters: {
-      status: initial.filters?.status ?? 'all',
+      status: normalizeStatusFilters(initial.filters?.status),
       search: initial.filters?.search ?? '',
       type:
         typeof initial.filters?.type === 'string' ? initial.filters?.type : ''
@@ -107,7 +105,14 @@ export function createStore(initial = {}) {
       const next = {
         ...state,
         ...patch,
-        filters: { ...state.filters, ...(patch.filters || {}) },
+        filters: {
+          ...state.filters,
+          ...(patch.filters || {}),
+          status:
+            patch.filters && 'status' in patch.filters
+              ? normalizeStatusFilters(patch.filters.status)
+              : state.filters.status
+        },
         board: { ...state.board, ...(patch.board || {}) },
         workspace: {
           current:
@@ -127,7 +132,7 @@ export function createStore(initial = {}) {
       if (
         next.selected_id === state.selected_id &&
         next.view === state.view &&
-        next.filters.status === state.filters.status &&
+        sameStatusFilters(next.filters.status, state.filters.status) &&
         next.filters.search === state.filters.search &&
         next.filters.type === state.filters.type &&
         next.board.closed_filter === state.board.closed_filter &&

--- a/app/state.test.js
+++ b/app/state.test.js
@@ -8,14 +8,28 @@ describe('state store', () => {
     const off = store.subscribe((s) => seen.push(s));
 
     store.setState({ selected_id: 'UI-1' });
-    store.setState({ filters: { status: 'open' } });
-    // no-op (unchanged)
-    store.setState({ filters: { status: 'open' } });
+    store.setState({ filters: { status: ['open'] } });
+    // no-op (equal selection, fresh array)
+    store.setState({ filters: { status: ['open'] } });
     off();
 
     expect(seen.length).toBe(2);
     const state = store.getState();
     expect(state.selected_id).toBe('UI-1');
-    expect(state.filters.status).toBe('open');
+    expect(state.filters.status).toEqual(['open']);
+  });
+
+  test('defaults the status filter to an empty selection', () => {
+    const store = createStore();
+
+    expect(store.getState().filters.status).toEqual([]);
+  });
+
+  test('normalizes a legacy scalar status filter', () => {
+    const store = createStore({
+      filters: { status: /** @type {any} */ ('open'), search: '', type: '' }
+    });
+
+    expect(store.getState().filters.status).toEqual(['open']);
   });
 });

--- a/app/styles.css
+++ b/app/styles.css
@@ -11,7 +11,11 @@
   /* Status base colors */
   --status-open-base: #51cb4e; /* open */
   --status-in-progress-base: #666666; /* in_progress */
+  --status-blocked-base: #c0392b; /* blocked */
+  --status-deferred-base: #5b7fa6; /* deferred */
   --status-closed-base: #5f26c9; /* closed */
+  --status-pinned-base: #f69842; /* pinned (machine-managed) */
+  --status-hooked-base: #6b7280; /* hooked (machine-managed) */
 
   /* Type base colors */
   --type-bug-base: #9f2011;
@@ -639,12 +643,40 @@ button:disabled {
     var(--status-in-progress-base) 90%,
     #000
   );
+  --badge-bg-blocked: color-mix(
+    in srgb,
+    var(--panel-bg) 85%,
+    var(--status-blocked-base)
+  );
+  --badge-fg-blocked: color-mix(in srgb, var(--status-blocked-base) 90%, #000);
+  --badge-bg-deferred: color-mix(
+    in srgb,
+    var(--panel-bg) 85%,
+    var(--status-deferred-base)
+  );
+  --badge-fg-deferred: color-mix(
+    in srgb,
+    var(--status-deferred-base) 90%,
+    #000
+  );
   --badge-bg-closed: color-mix(
     in srgb,
     var(--panel-bg) 85%,
     var(--status-closed-base)
   );
   --badge-fg-closed: color-mix(in srgb, var(--status-closed-base) 90%, #000);
+  --badge-bg-pinned: color-mix(
+    in srgb,
+    var(--panel-bg) 85%,
+    var(--status-pinned-base)
+  );
+  --badge-fg-pinned: color-mix(in srgb, var(--status-pinned-base) 90%, #000);
+  /* `hooked` shares in_progress's neutral grey on purpose (both are "in
+     flight"), so it cannot be told apart by hue. It is set apart structurally
+     instead: an unfilled, dashed badge (see `.is-hooked` below) that reads as
+     machine-managed and recedes next to the filled human statuses. */
+  --badge-bg-hooked: transparent;
+  --badge-fg-hooked: color-mix(in srgb, var(--status-hooked-base) 90%, #000);
 
   /* Priority palette mapped to provided colors */
   /* p0 -> bug, p1 -> epic, p2 -> task, p3 -> feature, p4 -> chore */
@@ -686,12 +718,41 @@ button:disabled {
       var(--status-in-progress-base) 75%,
       #fff
     );
+    --badge-bg-blocked: color-mix(
+      in srgb,
+      var(--panel-bg) 80%,
+      var(--status-blocked-base)
+    );
+    --badge-fg-blocked: color-mix(
+      in srgb,
+      var(--status-blocked-base) 75%,
+      #fff
+    );
+    --badge-bg-deferred: color-mix(
+      in srgb,
+      var(--panel-bg) 80%,
+      var(--status-deferred-base)
+    );
+    --badge-fg-deferred: color-mix(
+      in srgb,
+      var(--status-deferred-base) 75%,
+      #fff
+    );
     --badge-bg-closed: color-mix(
       in srgb,
       var(--panel-bg) 80%,
       var(--status-closed-base)
     );
     --badge-fg-closed: color-mix(in srgb, var(--status-closed-base) 75%, #fff);
+    --badge-bg-pinned: color-mix(
+      in srgb,
+      var(--panel-bg) 80%,
+      var(--status-pinned-base)
+    );
+    --badge-fg-pinned: color-mix(in srgb, var(--status-pinned-base) 75%, #fff);
+    /* Unfilled + dashed; see the light palette's note. */
+    --badge-bg-hooked: transparent;
+    --badge-fg-hooked: color-mix(in srgb, var(--status-hooked-base) 75%, #fff);
 
     --badge-bg-p0: color-mix(
       in srgb,
@@ -743,12 +804,37 @@ html[data-theme='dark'] {
     var(--status-in-progress-base) 75%,
     #fff
   );
+  --badge-bg-blocked: color-mix(
+    in srgb,
+    var(--panel-bg) 80%,
+    var(--status-blocked-base)
+  );
+  --badge-fg-blocked: color-mix(in srgb, var(--status-blocked-base) 75%, #fff);
+  --badge-bg-deferred: color-mix(
+    in srgb,
+    var(--panel-bg) 80%,
+    var(--status-deferred-base)
+  );
+  --badge-fg-deferred: color-mix(
+    in srgb,
+    var(--status-deferred-base) 75%,
+    #fff
+  );
   --badge-bg-closed: color-mix(
     in srgb,
     var(--panel-bg) 80%,
     var(--status-closed-base)
   );
   --badge-fg-closed: color-mix(in srgb, var(--status-closed-base) 75%, #fff);
+  --badge-bg-pinned: color-mix(
+    in srgb,
+    var(--panel-bg) 80%,
+    var(--status-pinned-base)
+  );
+  --badge-fg-pinned: color-mix(in srgb, var(--status-pinned-base) 75%, #fff);
+  /* Unfilled + dashed; see the light palette's note. */
+  --badge-bg-hooked: transparent;
+  --badge-fg-hooked: color-mix(in srgb, var(--status-hooked-base) 75%, #fff);
 
   --badge-bg-p0: color-mix(in srgb, var(--panel-bg) 80%, var(--type-bug-base));
   --badge-fg-p0: color-mix(in srgb, var(--type-bug-base) 75%, #fff);
@@ -780,10 +866,34 @@ html[data-theme='dark'] {
   background: var(--badge-bg-in-progress);
   color: var(--badge-fg-in-progress);
 }
+.status-badge.is-blocked,
+.badge-select.badge--status.is-blocked {
+  background: var(--badge-bg-blocked);
+  color: var(--badge-fg-blocked);
+}
+.status-badge.is-deferred,
+.badge-select.badge--status.is-deferred {
+  background: var(--badge-bg-deferred);
+  color: var(--badge-fg-deferred);
+}
 .status-badge.is-closed,
 .badge-select.badge--status.is-closed {
   background: var(--badge-bg-closed);
   color: var(--badge-fg-closed);
+}
+.status-badge.is-pinned,
+.badge-select.badge--status.is-pinned {
+  background: var(--badge-bg-pinned);
+  color: var(--badge-fg-pinned);
+}
+/* Machine-managed: unfilled with a dashed border so it never reads as a
+   human's `in_progress`, which shares the same neutral grey. */
+.status-badge.is-hooked,
+.badge-select.badge--status.is-hooked {
+  background: var(--badge-bg-hooked);
+  color: var(--badge-fg-hooked);
+  border-style: dashed;
+  border-color: color-mix(in srgb, currentColor 55%, transparent);
 }
 
 .priority-badge.is-p0,

--- a/app/styles.css
+++ b/app/styles.css
@@ -1104,8 +1104,33 @@ html[data-theme='dark'] {
   background: color-mix(in srgb, var(--link) 10%, transparent);
 }
 
-.filter-dropdown__option input[type='checkbox'] {
+.filter-dropdown__option input[type='checkbox'],
+.filter-dropdown__option input[type='radio'] {
   margin: 0;
+}
+
+/* Status checkboxes are inert while the Ready scope owns the selection */
+.filter-dropdown__option.is-disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.filter-dropdown__option.is-disabled:hover {
+  background: transparent;
+}
+
+.filter-dropdown__group-label {
+  padding: 6px 10px 2px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.filter-dropdown__divider {
+  margin: 4px 0;
+  border-top: 1px solid var(--border);
 }
 
 /* Inline, minimal text input for table editing */

--- a/app/utils/status-badge.js
+++ b/app/utils/status-badge.js
@@ -1,33 +1,20 @@
+import { statusLabel } from './status.js';
+
 /**
  * Create a colored badge for a status value.
  *
- * @param {string | null | undefined} status - 'open' | 'in_progress' | 'closed'
+ * @param {string | null | undefined} status - Any status bd can report.
  * @returns {HTMLSpanElement}
  */
 export function createStatusBadge(status) {
   const el = document.createElement('span');
   el.className = 'status-badge';
   const s = String(status || 'open');
+  const label = statusLabel(s);
   el.classList.add(`is-${s}`);
   el.setAttribute('role', 'img');
-  el.setAttribute('title', labelForStatus(s));
-  el.setAttribute('aria-label', `Status: ${labelForStatus(s)}`);
-  el.textContent = labelForStatus(s);
+  el.setAttribute('title', label);
+  el.setAttribute('aria-label', `Status: ${label}`);
+  el.textContent = label;
   return el;
-}
-
-/**
- * @param {string} s
- */
-function labelForStatus(s) {
-  switch (s) {
-    case 'open':
-      return 'Open';
-    case 'in_progress':
-      return 'In progress';
-    case 'closed':
-      return 'Closed';
-    default:
-      return 'Unknown';
-  }
 }

--- a/app/utils/status-badge.test.js
+++ b/app/utils/status-badge.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+import { createStatusBadge } from './status-badge.js';
+
+describe('utils/status-badge', () => {
+  test('renders every bd status with modifier class and accessible labels', () => {
+    const statuses = [
+      ['open', 'Open'],
+      ['in_progress', 'In progress'],
+      ['blocked', 'Blocked'],
+      ['deferred', 'Deferred'],
+      ['closed', 'Closed'],
+      ['pinned', 'Pinned'],
+      ['hooked', 'Hooked']
+    ];
+    for (const [s, label] of statuses) {
+      const el = createStatusBadge(s);
+      expect(el.classList.contains('status-badge')).toBe(true);
+      expect(el.classList.contains(`is-${s}`)).toBe(true);
+      expect(el.getAttribute('role')).toBe('img');
+      expect(el.getAttribute('aria-label')).toBe(`Status: ${label}`);
+      expect(el.textContent).toBe(label);
+    }
+  });
+});

--- a/app/utils/status.js
+++ b/app/utils/status.js
@@ -1,25 +1,74 @@
 /**
- * Known status values in canonical order.
- *
- * @type {Array<'open'|'in_progress'|'closed'>}
+ * @import { Status } from '../protocol.js'
  */
-export const STATUSES = ['open', 'in_progress', 'closed'];
+import { SETTABLE_STATUSES, STATUSES, isSettableStatus } from '../protocol.js';
+
+// Guiding rule: render everything, offer only what a human should set.
+// `STATUSES` is every status bd can emit, so all of them get a label and a
+// badge colour. `SETTABLE_STATUSES` drives the editable selects: `pinned` and
+// `hooked` are owned by bd's own machinery and hand-setting them desyncs it.
+// Both live in protocol.js because the server validates against the settable
+// set; re-exported here as the view layer's status vocabulary.
+export { SETTABLE_STATUSES, STATUSES, isSettableStatus };
 
 /**
- * Map canonical status to display label.
+ * Map a status to its display label. Unknown values are title-cased rather
+ * than defaulted to a known status: a status bdui has never heard of must not
+ * masquerade as `Open`.
  *
  * @param {string | null | undefined} status
  * @returns {string}
  */
 export function statusLabel(status) {
-  switch ((status || '').toString()) {
+  const raw = (status || '').toString();
+  switch (raw) {
     case 'open':
       return 'Open';
     case 'in_progress':
       return 'In progress';
+    case 'blocked':
+      return 'Blocked';
+    case 'deferred':
+      return 'Deferred';
     case 'closed':
       return 'Closed';
+    case 'pinned':
+      return 'Pinned';
+    case 'hooked':
+      return 'Hooked';
     default:
-      return (status || '').toString() || 'Open';
+      return titleize(raw);
   }
+}
+
+/**
+ * Options for an editable status `<select>`: the settable statuses, plus the
+ * issue's current status when bd has it in a state we don't offer (e.g.
+ * `pinned`) — otherwise the select would silently display the wrong option.
+ *
+ * @param {string | null | undefined} current
+ * @returns {Array<Status | string>}
+ */
+export function statusOptions(current) {
+  const cur = (current || '').toString();
+  /** @type {string[]} */
+  const settable = [...SETTABLE_STATUSES];
+  if (cur && !settable.includes(cur)) {
+    return [...settable, cur];
+  }
+  return settable;
+}
+
+/**
+ * Title-case a raw status: `in_review` → `In review`, empty → `Unknown`.
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function titleize(raw) {
+  if (!raw) {
+    return 'Unknown';
+  }
+  const words = raw.replace(/_/g, ' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
 }

--- a/app/utils/status.js
+++ b/app/utils/status.js
@@ -12,6 +12,85 @@ import { SETTABLE_STATUSES, STATUSES, isSettableStatus } from '../protocol.js';
 export { SETTABLE_STATUSES, STATUSES, isSettableStatus };
 
 /**
+ * One entry of the issue list's status filter: any status bd can report, plus
+ * the derived `ready` membership. There is no `all` member — an empty
+ * selection *is* "all issues".
+ *
+ * @typedef {'ready' | Status} StatusFilter
+ */
+
+/**
+ * Statuses offered as filter checkboxes. `hooked` is excluded: it is
+ * gate-managed by bd and the all-issues query does not pass `--include-gates`,
+ * so a hooked filter would be a dead option that always yields nothing.
+ * (`pinned` issues DO appear in a normal bd list, so it stays.)
+ *
+ * @type {readonly Status[]}
+ */
+export const FILTERABLE_STATUSES = STATUSES.filter((s) => s !== 'hooked');
+
+/**
+ * Every value a status filter entry may take.
+ *
+ * @type {readonly StatusFilter[]}
+ */
+const STATUS_FILTER_VALUES = ['ready', ...STATUSES];
+
+/**
+ * Normalize any stored, persisted or legacy status filter into the canonical
+ * array form and enforce the model's invariant: the result is either exactly
+ * `['ready']` or a subset of the stored statuses, never a mix.
+ *
+ * `ready` is not a per-row predicate — readiness is a top-level membership
+ * concept the server answers with its own list, and a list row carries no
+ * dependency-graph state to evaluate it client-side. It therefore cannot join
+ * a union with stored statuses; a mixed value resolves to the stored statuses,
+ * which are the narrower, evaluable half of the selection.
+ *
+ * Accepts the legacy scalar form (`'open'`, `'all'`) so a selection persisted
+ * by an older build survives the upgrade.
+ *
+ * @param {unknown} value
+ * @returns {StatusFilter[]}
+ */
+export function normalizeStatusFilters(value) {
+  /** @type {string[]} */
+  let raw = [];
+  if (Array.isArray(value)) {
+    raw = value.map((v) => String(v));
+  } else if (typeof value === 'string' && value !== '' && value !== 'all') {
+    raw = [value];
+  }
+
+  /** @type {StatusFilter[]} */
+  const selected = [];
+  for (const entry of raw) {
+    const known = /** @type {readonly string[]} */ (
+      STATUS_FILTER_VALUES
+    ).includes(entry);
+    if (known && !(/** @type {string[]} */ (selected).includes(entry))) {
+      selected.push(/** @type {StatusFilter} */ (entry));
+    }
+  }
+
+  const stored = selected.filter((s) => s !== 'ready');
+  if (stored.length > 0) {
+    return stored;
+  }
+  return selected.length > 0 ? ['ready'] : [];
+}
+
+/**
+ * Whether two status filter selections are equal.
+ *
+ * @param {readonly StatusFilter[]} a
+ * @param {readonly StatusFilter[]} b
+ */
+export function sameStatusFilters(a, b) {
+  return a.length === b.length && a.every((s, i) => s === b[i]);
+}
+
+/**
  * Map a status to its display label. Unknown values are title-cased rather
  * than defaulted to a known status: a status bdui has never heard of must not
  * masquerade as `Open`.

--- a/app/utils/status.test.js
+++ b/app/utils/status.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest';
+import {
+  SETTABLE_STATUSES,
+  STATUSES,
+  isSettableStatus,
+  statusLabel,
+  statusOptions
+} from './status.js';
+
+describe('utils/status', () => {
+  test('STATUSES lists every bd status in canonical order', () => {
+    expect(STATUSES).toEqual([
+      'open',
+      'in_progress',
+      'blocked',
+      'deferred',
+      'closed',
+      'pinned',
+      'hooked'
+    ]);
+  });
+
+  test('SETTABLE_STATUSES omits the machine-managed statuses', () => {
+    expect(SETTABLE_STATUSES).toEqual([
+      'open',
+      'in_progress',
+      'blocked',
+      'deferred',
+      'closed'
+    ]);
+    expect(SETTABLE_STATUSES).not.toContain('pinned');
+    expect(SETTABLE_STATUSES).not.toContain('hooked');
+    for (const s of SETTABLE_STATUSES) {
+      expect(STATUSES).toContain(s);
+    }
+  });
+
+  test('labels every known status', () => {
+    const labels = [
+      ['open', 'Open'],
+      ['in_progress', 'In progress'],
+      ['blocked', 'Blocked'],
+      ['deferred', 'Deferred'],
+      ['closed', 'Closed'],
+      ['pinned', 'Pinned'],
+      ['hooked', 'Hooked']
+    ];
+    for (const [status, label] of labels) {
+      expect(statusLabel(status)).toBe(label);
+    }
+  });
+
+  test('titleizes unknown statuses instead of masquerading as Open', () => {
+    expect(statusLabel('in_review')).toBe('In review');
+    expect(statusLabel('wibble')).toBe('Wibble');
+  });
+
+  test('reports missing status as Unknown, never Open', () => {
+    expect(statusLabel('')).toBe('Unknown');
+    expect(statusLabel(null)).toBe('Unknown');
+    expect(statusLabel(undefined)).toBe('Unknown');
+  });
+
+  test('statusOptions offers the settable statuses', () => {
+    expect(statusOptions('open')).toEqual(SETTABLE_STATUSES);
+    expect(statusOptions('')).toEqual(SETTABLE_STATUSES);
+    expect(statusOptions(undefined)).toEqual(SETTABLE_STATUSES);
+  });
+
+  test('statusOptions appends a current status outside the settable set', () => {
+    expect(statusOptions('pinned')).toEqual([...SETTABLE_STATUSES, 'pinned']);
+    expect(statusOptions('hooked')).toEqual([...SETTABLE_STATUSES, 'hooked']);
+  });
+
+  test('isSettableStatus gates exactly the human-settable statuses', () => {
+    /** @type {readonly string[]} */
+    const settable = SETTABLE_STATUSES;
+    for (const s of STATUSES) {
+      expect(isSettableStatus(s)).toBe(settable.includes(s));
+    }
+    expect(isSettableStatus('pinned')).toBe(false);
+    expect(isSettableStatus('hooked')).toBe(false);
+    expect(isSettableStatus('in_review')).toBe(false);
+    expect(isSettableStatus('')).toBe(false);
+  });
+});

--- a/app/views/board.js
+++ b/app/views/board.js
@@ -1,3 +1,6 @@
+/**
+ * @import { Status } from '../protocol.js'
+ */
 import { html, render } from 'lit-html';
 import { createListSelectors } from '../data/list-selectors.js';
 import { cmpClosedDesc, cmpPriorityThenCreated } from '../data/sort.js';
@@ -11,7 +14,7 @@ import { createTypeBadge } from '../utils/type-badge.js';
  * @typedef {{
  *   id: string,
  *   title?: string,
- *   status?: 'open'|'in_progress'|'closed',
+ *   status?: Status,
  *   priority?: number,
  *   issue_type?: string,
  *   created_at?: number,

--- a/app/views/board.js
+++ b/app/views/board.js
@@ -26,10 +26,15 @@ import { createTypeBadge } from '../utils/type-badge.js';
 /**
  * Map column IDs to their corresponding status values.
  *
- * @type {Record<string, 'open'|'in_progress'|'closed'>}
+ * The Blocked lane is the union of dependency-blocked issues and issues whose
+ * stored status is `blocked`. A drop must produce membership in the lane it
+ * lands on, and setting `open` only lands in Blocked when the issue happens to
+ * be dependency-blocked — so `blocked-col` sets the stored status `blocked`.
+ *
+ * @type {Record<string, 'open'|'in_progress'|'blocked'|'closed'>}
  */
 const COLUMN_STATUS_MAP = {
-  'blocked-col': 'open',
+  'blocked-col': 'blocked',
   'ready-col': 'open',
   'in-progress-col': 'in_progress',
   'closed-col': 'closed'
@@ -257,7 +262,7 @@ export function createBoardView(
    * Update issue status via WebSocket transport.
    *
    * @param {string} issue_id
-   * @param {'open'|'in_progress'|'closed'} new_status
+   * @param {'open'|'in_progress'|'blocked'|'closed'} new_status
    */
   async function updateIssueStatus(issue_id, new_status) {
     if (!transport) {
@@ -584,8 +589,11 @@ export function createBoardView(
           'tab:board:in-progress',
           'in_progress'
         );
-        const blocked = selectors.selectBoardColumn(
-          'tab:board:blocked',
+        // Blocked is the union of dependency-blocked issues (`bd blocked`)
+        // and issues whose stored status is `blocked`; the two are disjoint
+        // queries but may overlap, so the selector dedupes by id.
+        const blocked = selectors.selectBoardColumnUnion(
+          ['tab:board:blocked', 'tab:board:status-blocked'],
           'blocked'
         );
         const ready_raw = selectors.selectBoardColumn(
@@ -660,6 +668,7 @@ export function createBoardView(
         const total_items =
           cnt('tab:board:ready') +
           cnt('tab:board:blocked') +
+          cnt('tab:board:status-blocked') +
           cnt('tab:board:in-progress') +
           cnt('tab:board:closed');
         const data = /** @type {any} */ (_data);

--- a/app/views/board.test.js
+++ b/app/views/board.test.js
@@ -374,3 +374,316 @@ describe('views/board', () => {
     expect(prog_ids).toEqual(['X-2']);
   });
 });
+
+describe('views/board Blocked lane union', () => {
+  test('shows issues whose stored status is blocked', async () => {
+    document.body.innerHTML = '<div id="m"></div>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('m'));
+
+    const issueStores = createTestIssueStores();
+    // Stored-status blocked issues never appear in `bd blocked`; they arrive
+    // on their own subscription.
+    issueStores.getStore('tab:board:status-blocked').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:status-blocked',
+      revision: 1,
+      issues: [
+        {
+          id: 'S-1',
+          title: 's1',
+          status: 'blocked',
+          priority: 1,
+          created_at: new Date('2025-10-21T07:00:00.000Z').getTime(),
+          updated_at: new Date('2025-10-21T07:00:00.000Z').getTime(),
+          issue_type: 'task'
+        }
+      ]
+    });
+
+    const view = createBoardView(
+      mount,
+      null,
+      () => {},
+      undefined,
+      undefined,
+      issueStores
+    );
+    await view.load();
+
+    const blocked_ids = Array.from(
+      mount.querySelectorAll('#blocked-col .board-card .mono')
+    ).map((el) => el.textContent?.trim());
+    expect(blocked_ids).toEqual(['S-1']);
+  });
+
+  test('still shows dependency-blocked issues', async () => {
+    document.body.innerHTML = '<div id="m"></div>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('m'));
+
+    const issueStores = createTestIssueStores();
+    // `bd blocked` reports dependency-blocked issues, whose own status is open.
+    issueStores.getStore('tab:board:blocked').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:blocked',
+      revision: 1,
+      issues: [
+        {
+          id: 'D-1',
+          title: 'd1',
+          status: 'open',
+          priority: 1,
+          created_at: new Date('2025-10-21T07:00:00.000Z').getTime(),
+          updated_at: new Date('2025-10-21T07:00:00.000Z').getTime(),
+          issue_type: 'task'
+        }
+      ]
+    });
+
+    const view = createBoardView(
+      mount,
+      null,
+      () => {},
+      undefined,
+      undefined,
+      issueStores
+    );
+    await view.load();
+
+    const blocked_ids = Array.from(
+      mount.querySelectorAll('#blocked-col .board-card .mono')
+    ).map((el) => el.textContent?.trim());
+    expect(blocked_ids).toEqual(['D-1']);
+  });
+
+  test('renders an issue in both blocked sources exactly once', async () => {
+    document.body.innerHTML = '<div id="m"></div>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('m'));
+
+    const both = {
+      id: 'X-1',
+      title: 'both',
+      status: 'blocked',
+      priority: 1,
+      created_at: new Date('2025-10-21T07:00:00.000Z').getTime(),
+      updated_at: new Date('2025-10-21T07:00:00.000Z').getTime(),
+      issue_type: 'task'
+    };
+    const issueStores = createTestIssueStores();
+    issueStores.getStore('tab:board:blocked').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:blocked',
+      revision: 1,
+      issues: [both]
+    });
+    issueStores.getStore('tab:board:status-blocked').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:status-blocked',
+      revision: 1,
+      issues: [{ ...both }]
+    });
+
+    const view = createBoardView(
+      mount,
+      null,
+      () => {},
+      undefined,
+      undefined,
+      issueStores
+    );
+    await view.load();
+
+    const cards = mount.querySelectorAll(
+      '#blocked-col .board-card[data-issue-id="X-1"]'
+    );
+    expect(cards.length).toBe(1);
+    const all_cards = mount.querySelectorAll('#blocked-col .board-card');
+    expect(all_cards.length).toBe(1);
+    const count = mount
+      .querySelector('#blocked-col .board-column__count')
+      ?.textContent?.trim();
+    expect(count).toBe('1');
+  });
+
+  test('does not fall back to the legacy fetch when only stored-blocked issues exist', async () => {
+    document.body.innerHTML = '<div id="m"></div>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('m'));
+
+    const issueStores = createTestIssueStores();
+    issueStores.getStore('tab:board:status-blocked').applyPush({
+      type: 'snapshot',
+      id: 'tab:board:status-blocked',
+      revision: 1,
+      issues: [
+        {
+          id: 'S-1',
+          title: 's1',
+          status: 'blocked',
+          priority: 1,
+          created_at: 10_000,
+          updated_at: 10_000,
+          issue_type: 'task'
+        }
+      ]
+    });
+
+    /** @type {string[]} */
+    const fetched = [];
+    const data = {
+      async getReady() {
+        fetched.push('ready');
+        return [];
+      },
+      async getBlocked() {
+        fetched.push('blocked');
+        return [{ id: 'LEGACY-1', title: 'legacy', updated_at: 1 }];
+      },
+      async getInProgress() {
+        fetched.push('in-progress');
+        return [];
+      },
+      async getClosed() {
+        fetched.push('closed');
+        return [];
+      }
+    };
+    const subscriptions = {
+      selectors: {
+        /** @param {string} id */
+        count(id) {
+          return id === 'tab:board:status-blocked' ? 1 : 0;
+        },
+        getIds() {
+          return [];
+        }
+      }
+    };
+
+    const view = createBoardView(
+      mount,
+      data,
+      () => {},
+      undefined,
+      subscriptions,
+      issueStores
+    );
+    await view.load();
+
+    // The stored-blocked subscription has items, so the legacy fallback must
+    // not run and must not overwrite the lane.
+    expect(fetched).toEqual([]);
+    const blocked_ids = Array.from(
+      mount.querySelectorAll('#blocked-col .board-card .mono')
+    ).map((el) => el.textContent?.trim());
+    expect(blocked_ids).toEqual(['S-1']);
+  });
+
+  test('dropping into the Blocked lane sets status blocked', async () => {
+    const { mount, calls } = await setupDropBoard();
+
+    dropOn(mount, 'blocked-col', 'S-1');
+    await flush();
+
+    expect(calls).toEqual([
+      ['update-status', { id: 'S-1', status: 'blocked' }]
+    ]);
+  });
+
+  test('dropping out of the Blocked lane sets the target column status', async () => {
+    const ready = await setupDropBoard();
+    dropOn(ready.mount, 'ready-col', 'S-1');
+    await flush();
+    expect(ready.calls).toEqual([
+      ['update-status', { id: 'S-1', status: 'open' }]
+    ]);
+
+    const in_progress = await setupDropBoard();
+    dropOn(in_progress.mount, 'in-progress-col', 'S-1');
+    await flush();
+    expect(in_progress.calls).toEqual([
+      ['update-status', { id: 'S-1', status: 'in_progress' }]
+    ]);
+
+    const closed = await setupDropBoard();
+    dropOn(closed.mount, 'closed-col', 'S-1');
+    await flush();
+    expect(closed.calls).toEqual([
+      ['update-status', { id: 'S-1', status: 'closed' }]
+    ]);
+  });
+});
+
+/**
+ * Flush pending microtasks so the async transport call settles.
+ */
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+/**
+ * Mount a board holding a single stored-blocked issue and capture the
+ * mutations dispatched through the transport.
+ *
+ * @returns {Promise<{ mount: HTMLElement, calls: Array<[string, unknown]> }>}
+ */
+async function setupDropBoard() {
+  document.body.innerHTML = '<div id="m"></div>';
+  const mount = /** @type {HTMLElement} */ (document.getElementById('m'));
+
+  const issueStores = createTestIssueStores();
+  issueStores.getStore('tab:board:status-blocked').applyPush({
+    type: 'snapshot',
+    id: 'tab:board:status-blocked',
+    revision: 1,
+    issues: [
+      {
+        id: 'S-1',
+        title: 's1',
+        status: 'blocked',
+        priority: 1,
+        created_at: new Date('2025-10-21T07:00:00.000Z').getTime(),
+        updated_at: new Date('2025-10-21T07:00:00.000Z').getTime(),
+        issue_type: 'task'
+      }
+    ]
+  });
+
+  /** @type {Array<[string, unknown]>} */
+  const calls = [];
+  const view = createBoardView(
+    mount,
+    null,
+    () => {},
+    undefined,
+    undefined,
+    issueStores,
+    async (type, payload) => {
+      calls.push([type, payload]);
+      return null;
+    }
+  );
+  await view.load();
+  return { mount, calls };
+}
+
+/**
+ * Dispatch a `drop` event on a board column with a stubbed dataTransfer.
+ * jsdom has no DataTransfer implementation, so the payload is stubbed.
+ *
+ * @param {HTMLElement} mount
+ * @param {string} col_id
+ * @param {string} issue_id
+ */
+function dropOn(mount, col_id, issue_id) {
+  const col = /** @type {HTMLElement} */ (mount.querySelector(`#${col_id}`));
+  const ev = new Event('drop', { bubbles: true, cancelable: true });
+  Object.defineProperty(ev, 'dataTransfer', {
+    value: {
+      getData() {
+        return issue_id;
+      }
+    }
+  });
+  col.dispatchEvent(ev);
+}

--- a/app/views/detail.edits.test.js
+++ b/app/views/detail.edits.test.js
@@ -163,4 +163,88 @@ describe('views/detail edits', () => {
     await vi.advanceTimersByTimeAsync(3000);
     vi.useRealTimers();
   });
+
+  test('status select offers only the human-settable statuses', async () => {
+    document.body.innerHTML =
+      '<section class="panel"><div id="mount"></div></section>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issue = { id: 'UI-20', title: 'T', status: 'open', priority: 2 };
+    const stores = {
+      /** @param {string} id */
+      snapshotFor(id) {
+        return id === 'detail:UI-20' ? [issue] : [];
+      },
+      subscribe() {
+        return () => {};
+      }
+    };
+    const send = mockSend(async () => {
+      throw new Error('Unexpected');
+    });
+    const view = createDetailView(mount, send, undefined, stores);
+    await view.load('UI-20');
+
+    const select = /** @type {HTMLSelectElement} */ (
+      mount.querySelector('select.badge--status')
+    );
+    expect(Array.from(select.options).map((o) => o.value)).toEqual([
+      'open',
+      'in_progress',
+      'blocked',
+      'deferred',
+      'closed'
+    ]);
+    expect(
+      Array.from(select.options).map((o) => (o.textContent || '').trim())
+    ).toEqual(['Open', 'In progress', 'Blocked', 'Deferred', 'Closed']);
+  });
+
+  test('status select shows a machine-managed current status but disables it', async () => {
+    document.body.innerHTML =
+      '<section class="panel"><div id="mount"></div></section>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issue = { id: 'UI-21', title: 'T', status: 'hooked', priority: 2 };
+    const stores = {
+      /** @param {string} id */
+      snapshotFor(id) {
+        return id === 'detail:UI-21' ? [issue] : [];
+      },
+      subscribe() {
+        return () => {};
+      }
+    };
+    const send = mockSend(async () => {
+      throw new Error('Unexpected');
+    });
+    const view = createDetailView(mount, send, undefined, stores);
+    await view.load('UI-21');
+
+    const select = /** @type {HTMLSelectElement} */ (
+      mount.querySelector('select.badge--status')
+    );
+    expect(Array.from(select.options).map((o) => o.value)).toEqual([
+      'open',
+      'in_progress',
+      'blocked',
+      'deferred',
+      'closed',
+      'hooked'
+    ]);
+    expect(select.value).toBe('hooked');
+    expect(select.classList.contains('is-hooked')).toBe(true);
+
+    // The out-of-set option must display (so the select tells the truth) but
+    // never be choosable: `update-status hooked` is rejected by the server.
+    const disabled_by_value = Object.fromEntries(
+      Array.from(select.options).map((o) => [o.value, o.disabled])
+    );
+    expect(disabled_by_value).toEqual({
+      open: false,
+      in_progress: false,
+      blocked: false,
+      deferred: false,
+      closed: false,
+      hooked: true
+    });
+  });
 });

--- a/app/views/detail.js
+++ b/app/views/detail.js
@@ -6,7 +6,11 @@ import { debug } from '../utils/logging.js';
 import { renderMarkdown } from '../utils/markdown.js';
 import { emojiForPriority } from '../utils/priority-badge.js';
 import { priority_levels } from '../utils/priority.js';
-import { statusLabel } from '../utils/status.js';
+import {
+  isSettableStatus,
+  statusLabel,
+  statusOptions
+} from '../utils/status.js';
 import { showToast } from '../utils/toast.js';
 import { createTypeBadge } from '../utils/type-badge.js';
 
@@ -1071,9 +1075,16 @@ export function createDetailView(
     >
       ${(() => {
         const cur = String(issue.status || 'open');
-        return ['open', 'in_progress', 'closed'].map(
+        return statusOptions(cur).map(
           (s) =>
-            html`<option value=${s} ?selected=${cur === s}>
+            // An out-of-set current status (e.g. `pinned`) is shown so the
+            // select tells the truth, but disabled so it cannot be re-chosen:
+            // the server rejects `update-status pinned`.
+            html`<option
+              value=${s}
+              ?selected=${cur === s}
+              ?disabled=${!isSettableStatus(s)}
+            >
               ${statusLabel(s)}
             </option>`
         );

--- a/app/views/issue-row.js
+++ b/app/views/issue-row.js
@@ -1,9 +1,16 @@
+/**
+ * @import { SettableStatus } from '../protocol.js'
+ */
 import { html } from 'lit-html';
 import { createIssueIdRenderer } from '../utils/issue-id-renderer.js';
 import { ISSUE_TYPES, typeLabel } from '../utils/issue-type.js';
 import { emojiForPriority } from '../utils/priority-badge.js';
 import { priority_levels } from '../utils/priority.js';
-import { statusLabel } from '../utils/status.js';
+import {
+  isSettableStatus,
+  statusLabel,
+  statusOptions
+} from '../utils/status.js';
 
 /**
  * @typedef {{ id: string, title?: string, status?: string, priority?: number, issue_type?: string, assignee?: string, dependency_count?: number, dependent_count?: number }} IssueRowData
@@ -15,7 +22,7 @@ import { statusLabel } from '../utils/status.js';
  *
  * @param {{
  *   navigate: (id: string) => void,
- *   onUpdate: (id: string, patch: { title?: string, assignee?: string, status?: 'open'|'in_progress'|'closed', priority?: number, issue_type?: string }) => Promise<void>,
+ *   onUpdate: (id: string, patch: { title?: string, assignee?: string, status?: SettableStatus, priority?: number, issue_type?: string }) => Promise<void>,
  *   requestRender: () => void,
  *   getSelectedId?: () => string | null,
  *   row_class?: string
@@ -170,9 +177,16 @@ export function createIssueRowRenderer(options) {
           .value=${cur_status}
           @change=${makeSelectChange(it.id, 'status')}
         >
-          ${['open', 'in_progress', 'closed'].map(
+          ${statusOptions(cur_status).map(
             (s) =>
-              html`<option value=${s} ?selected=${cur_status === s}>
+              // An out-of-set current status (e.g. `pinned`) is shown so the
+              // select tells the truth, but disabled so it cannot be re-chosen:
+              // the server rejects `update-status pinned`.
+              html`<option
+                value=${s}
+                ?selected=${cur_status === s}
+                ?disabled=${!isSettableStatus(s)}
+              >
                 ${statusLabel(s)}
               </option>`
           )}

--- a/app/views/list.fast-switch.test.js
+++ b/app/views/list.fast-switch.test.js
@@ -116,7 +116,7 @@ describe('list view — fast filter switches', () => {
     // out-of-order. The Ready scope disables the status checkboxes, so leaving
     // it is part of the switch.
     selectScope(mount, 'Ready only');
-    selectScope(mount, 'All issues');
+    selectScope(mount, 'By status');
     toggleFilter(mount, 0, 'In progress');
 
     const inProg = [

--- a/app/views/list.fast-switch.test.js
+++ b/app/views/list.fast-switch.test.js
@@ -27,6 +27,27 @@ function toggleFilter(mount, dropdownIndex, optionText) {
   checkbox.click();
 }
 
+/**
+ * Helper to pick a scope radio in the status dropdown.
+ *
+ * @param {HTMLElement} mount - The container element
+ * @param {string} label - Visible label of the radio
+ */
+function selectScope(mount, label) {
+  const dropdown = mount.querySelectorAll('.filter-dropdown')[0];
+  const trigger = /** @type {HTMLButtonElement} */ (
+    dropdown.querySelector('.filter-dropdown__trigger')
+  );
+  trigger.click();
+  const option = Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--scope')
+  ).find((opt) => (opt.textContent || '').trim() === label);
+  const radio = /** @type {HTMLInputElement} */ (
+    option?.querySelector('input[type="radio"]')
+  );
+  radio.click();
+}
+
 function createTestIssueStores() {
   /** @type {Map<string, any>} */
   const stores = new Map();
@@ -91,8 +112,11 @@ describe('list view — fast filter switches', () => {
     await view.load();
     expect(mount.querySelectorAll('tr.issue-row').length).toBe(0);
 
-    // Simulate quick switch: ready -> in_progress while snapshots arrive out-of-order
-    toggleFilter(mount, 0, 'Ready');
+    // Simulate quick switch: ready -> in_progress while snapshots arrive
+    // out-of-order. The Ready scope disables the status checkboxes, so leaving
+    // it is part of the switch.
+    selectScope(mount, 'Ready only');
+    selectScope(mount, 'All issues');
     toggleFilter(mount, 0, 'In progress');
 
     const inProg = [

--- a/app/views/list.inline-edits.test.js
+++ b/app/views/list.inline-edits.test.js
@@ -223,4 +223,105 @@ describe('views/list inline edits', () => {
     );
     expect(typeSel2.value).toBe('feature');
   });
+
+  test('status select offers only the human-settable statuses', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issueStores = createTestIssueStores();
+    issueStores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: [
+        {
+          id: 'UI-1',
+          title: 'One',
+          status: 'open',
+          priority: 1,
+          issue_type: 'task'
+        }
+      ]
+    });
+    const view = createListView(
+      mount,
+      async () => [],
+      undefined,
+      undefined,
+      undefined,
+      issueStores
+    );
+    await view.load();
+
+    const select = /** @type {HTMLSelectElement} */ (
+      mount.querySelector(
+        'tr.issue-row[data-issue-id="UI-1"] select.badge--status'
+      )
+    );
+    expect(Array.from(select.options).map((o) => o.value)).toEqual([
+      'open',
+      'in_progress',
+      'blocked',
+      'deferred',
+      'closed'
+    ]);
+  });
+
+  test('status select shows a machine-managed current status but disables it', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issueStores = createTestIssueStores();
+    issueStores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: [
+        {
+          id: 'UI-9',
+          title: 'Pinned one',
+          status: 'pinned',
+          priority: 1,
+          issue_type: 'task'
+        }
+      ]
+    });
+    const view = createListView(
+      mount,
+      async () => [],
+      undefined,
+      undefined,
+      undefined,
+      issueStores
+    );
+    await view.load();
+
+    const select = /** @type {HTMLSelectElement} */ (
+      mount.querySelector(
+        'tr.issue-row[data-issue-id="UI-9"] select.badge--status'
+      )
+    );
+    expect(Array.from(select.options).map((o) => o.value)).toEqual([
+      'open',
+      'in_progress',
+      'blocked',
+      'deferred',
+      'closed',
+      'pinned'
+    ]);
+    expect(select.value).toBe('pinned');
+    expect(select.classList.contains('is-pinned')).toBe(true);
+
+    // The out-of-set option must display (so the select tells the truth) but
+    // never be choosable: `update-status pinned` is rejected by the server.
+    const disabled_by_value = Object.fromEntries(
+      Array.from(select.options).map((o) => [o.value, o.disabled])
+    );
+    expect(disabled_by_value).toEqual({
+      open: false,
+      in_progress: false,
+      blocked: false,
+      deferred: false,
+      closed: false,
+      pinned: true
+    });
+  });
 });

--- a/app/views/list.js
+++ b/app/views/list.js
@@ -1,16 +1,19 @@
+/**
+ * @import { Status } from '../protocol.js'
+ */
 import { html, render } from 'lit-html';
 import { createListSelectors } from '../data/list-selectors.js';
 import { cmpClosedDesc } from '../data/sort.js';
 import { ISSUE_TYPES, typeLabel } from '../utils/issue-type.js';
 import { issueHashFor } from '../utils/issue-url.js';
 import { debug } from '../utils/logging.js';
-import { statusLabel } from '../utils/status.js';
+import { STATUSES, statusLabel } from '../utils/status.js';
 import { createIssueRowRenderer } from './issue-row.js';
 
 // List view implementation; requires a transport send function.
 
 /**
- * @typedef {{ id: string, title?: string, status?: 'closed'|'open'|'in_progress', priority?: number, issue_type?: string, assignee?: string, labels?: string[] }} Issue
+ * @typedef {{ id: string, title?: string, status?: Status, priority?: number, issue_type?: string, assignee?: string, labels?: string[] }} Issue
  */
 
 /**
@@ -241,7 +244,14 @@ export function createListView(
             <span class="filter-dropdown__arrow">▾</span>
           </button>
           <div class="filter-dropdown__menu">
-            ${['ready', 'open', 'in_progress', 'closed'].map(
+            <!--
+              Exclude 'hooked': it is gate-managed by bd, and the all-issues
+              query does not pass --include-gates, so hooked issues never appear
+              in the result set. Offering it as a filter would be a dead option
+              that always yields nothing. (pinned issues DO appear in a normal
+              bd list, so it stays.) STATUSES still renders hooked badges.
+            -->
+            ${['ready', ...STATUSES.filter((s) => s !== 'hooked')].map(
               (s) => html`
                 <label class="filter-dropdown__option">
                   <input
@@ -249,7 +259,7 @@ export function createListView(
                     .checked=${status_filters.includes(s)}
                     @change=${() => toggleStatusFilter(s)}
                   />
-                  ${s === 'ready' ? 'Ready' : statusLabel(s)}
+                  ${statusLabel(s)}
                 </label>
               `
             )}

--- a/app/views/list.js
+++ b/app/views/list.js
@@ -284,7 +284,9 @@ export function createListView(
             -->
             <div class="filter-dropdown__group-label">Scope</div>
             ${[
-              { scope: /** @type {const} */ ('all'), label: 'All issues' },
+              // "By status" names the mode, not the result: it stays accurate
+              // once a checkbox narrows the list, where "All issues" would not.
+              { scope: /** @type {const} */ ('all'), label: 'By status' },
               { scope: /** @type {const} */ ('ready'), label: 'Ready only' }
             ].map(
               (opt) => html`

--- a/app/views/list.js
+++ b/app/views/list.js
@@ -1,5 +1,6 @@
 /**
  * @import { Status } from '../protocol.js'
+ * @import { StatusFilter } from '../utils/status.js'
  */
 import { html, render } from 'lit-html';
 import { createListSelectors } from '../data/list-selectors.js';
@@ -7,7 +8,12 @@ import { cmpClosedDesc } from '../data/sort.js';
 import { ISSUE_TYPES, typeLabel } from '../utils/issue-type.js';
 import { issueHashFor } from '../utils/issue-url.js';
 import { debug } from '../utils/logging.js';
-import { STATUSES, statusLabel } from '../utils/status.js';
+import {
+  FILTERABLE_STATUSES,
+  normalizeStatusFilters,
+  sameStatusFilters,
+  statusLabel
+} from '../utils/status.js';
 import { createIssueRowRenderer } from './issue-row.js';
 
 // List view implementation; requires a transport send function.
@@ -49,7 +55,7 @@ export function createListView(
   const log = debug('views:list');
   // Touch unused param to satisfy lint rules without impacting behavior
   /** @type {any} */ (void _subscriptions);
-  /** @type {string[]} */
+  /** @type {StatusFilter[]} */
   let status_filters = [];
   /** @type {string} */
   let search_text = '';
@@ -63,18 +69,6 @@ export function createListView(
   let unsubscribe = null;
   let status_dropdown_open = false;
   let type_dropdown_open = false;
-
-  /**
-   * Normalize legacy string filter to array format.
-   *
-   * @param {string | string[] | undefined} val
-   * @returns {string[]}
-   */
-  function normalizeStatusFilter(val) {
-    if (Array.isArray(val)) return val;
-    if (typeof val === 'string' && val !== '' && val !== 'all') return [val];
-    return [];
-  }
 
   /**
    * Normalize legacy string filter to array format.
@@ -103,21 +97,48 @@ export function createListView(
   });
 
   /**
-   * Toggle a status filter chip.
+   * Apply a new status selection: publish it and refetch the list.
    *
-   * @param {string} status
+   * @param {StatusFilter[]} next
    */
-  const toggleStatusFilter = async (status) => {
-    if (status_filters.includes(status)) {
-      status_filters = status_filters.filter((s) => s !== status);
-    } else {
-      status_filters = [...status_filters, status];
-    }
-    log('status toggle %s -> %o', status, status_filters);
+  const applyStatusFilters = async (next) => {
+    // Normalize here too: the store normalizes what it publishes, and a local
+    // value that disagreed with it would survive — the store suppresses the
+    // notification when its own value is unchanged.
+    status_filters = normalizeStatusFilters(next);
     if (store) {
       store.setState({ filters: { status: status_filters } });
     }
     await load();
+  };
+
+  /**
+   * Toggle a stored status. Selecting one leaves the `ready` scope: readiness
+   * is a membership the server answers with its own list, so it cannot be
+   * unioned with statuses the client filters row by row.
+   *
+   * @param {Status} status
+   */
+  const toggleStatusFilter = async (status) => {
+    const stored = status_filters.filter((s) => s !== 'ready');
+    const next = stored.includes(status)
+      ? stored.filter((s) => s !== status)
+      : [...stored, status];
+    log('status toggle %s -> %o', status, next);
+    await applyStatusFilters(next);
+  };
+
+  /**
+   * Select the list scope. `ready` is exclusive with the stored statuses, so
+   * picking it clears them.
+   *
+   * @param {'all' | 'ready'} scope
+   */
+  const selectStatusScope = async (scope) => {
+    /** @type {StatusFilter[]} */
+    const next = scope === 'ready' ? ['ready'] : [];
+    log('status scope %s', scope);
+    await applyStatusFilters(next);
   };
 
   /**
@@ -196,7 +217,7 @@ export function createListView(
   if (store) {
     const s = store.getState();
     if (s && s.filters && typeof s.filters === 'object') {
-      status_filters = normalizeStatusFilter(s.filters.status);
+      status_filters = normalizeStatusFilters(s.filters.status);
       search_text = s.filters.search || '';
       type_filters = normalizeTypeFilter(s.filters.type);
     }
@@ -209,10 +230,17 @@ export function createListView(
    * Build lit-html template for the list view.
    */
   function template() {
+    // `ready` is a server-side membership, never a row predicate; every other
+    // entry narrows the rows as a union.
+    const is_ready_scope = status_filters.includes('ready');
+    const stored_status_filters = status_filters.filter((s) => s !== 'ready');
+
     let filtered = issues_cache;
-    if (status_filters.length > 0 && !status_filters.includes('ready')) {
+    if (stored_status_filters.length > 0) {
       filtered = filtered.filter((it) =>
-        status_filters.includes(String(it.status || ''))
+        /** @type {string[]} */ (stored_status_filters).includes(
+          String(it.status || '')
+        )
       );
     }
     if (search_text) {
@@ -229,7 +257,10 @@ export function createListView(
       );
     }
     // Sorting: closed list is a special case → sort by closed_at desc only
-    if (status_filters.length === 1 && status_filters[0] === 'closed') {
+    if (
+      stored_status_filters.length === 1 &&
+      stored_status_filters[0] === 'closed'
+    ) {
       filtered = filtered.slice().sort(cmpClosedDesc);
     }
 
@@ -245,18 +276,48 @@ export function createListView(
           </button>
           <div class="filter-dropdown__menu">
             <!--
-              Exclude 'hooked': it is gate-managed by bd, and the all-issues
-              query does not pass --include-gates, so hooked issues never appear
-              in the result set. Offering it as a filter would be a dead option
-              that always yields nothing. (pinned issues DO appear in a normal
-              bd list, so it stays.) STATUSES still renders hooked badges.
+              Scope and status are separate concepts, so they are separate
+              controls: "Ready only" is a server-side membership that cannot be
+              combined with a client-side status union, and a radio pair makes
+              that exclusivity visible before the click instead of silently
+              clearing the checkboxes after it.
             -->
-            ${['ready', ...STATUSES.filter((s) => s !== 'hooked')].map(
+            <div class="filter-dropdown__group-label">Scope</div>
+            ${[
+              { scope: /** @type {const} */ ('all'), label: 'All issues' },
+              { scope: /** @type {const} */ ('ready'), label: 'Ready only' }
+            ].map(
+              (opt) => html`
+                <label
+                  class="filter-dropdown__option filter-dropdown__option--scope"
+                >
+                  <input
+                    type="radio"
+                    name="list-status-scope"
+                    .checked=${opt.scope === 'ready'
+                      ? is_ready_scope
+                      : !is_ready_scope}
+                    @change=${() => selectStatusScope(opt.scope)}
+                  />
+                  ${opt.label}
+                </label>
+              `
+            )}
+            <div class="filter-dropdown__divider" role="separator"></div>
+            <div class="filter-dropdown__group-label">Status</div>
+            ${FILTERABLE_STATUSES.map(
               (s) => html`
-                <label class="filter-dropdown__option">
+                <label
+                  class="filter-dropdown__option filter-dropdown__option--status ${is_ready_scope
+                    ? 'is-disabled'
+                    : ''}"
+                >
                   <input
                     type="checkbox"
-                    .checked=${status_filters.includes(s)}
+                    ?disabled=${is_ready_scope}
+                    .checked=${
+                      /** @type {string[]} */ (status_filters).includes(s)
+                    }
                     @change=${() => toggleStatusFilter(s)}
                   />
                   ${statusLabel(s)}
@@ -542,11 +603,10 @@ export function createListView(
         doRender();
       }
       if (s.filters && typeof s.filters === 'object') {
-        const next_status = normalizeStatusFilter(s.filters.status);
+        const next_status = normalizeStatusFilters(s.filters.status);
         const next_search = s.filters.search || '';
         let needs_render = false;
-        const status_changed =
-          JSON.stringify(next_status) !== JSON.stringify(status_filters);
+        const status_changed = !sameStatusFilters(next_status, status_filters);
         if (status_changed) {
           status_filters = next_status;
           // Reload on any status scope change to keep cache correct

--- a/app/views/list.status-scope.test.js
+++ b/app/views/list.status-scope.test.js
@@ -1,0 +1,333 @@
+import { describe, expect, test } from 'vitest';
+import { createSubscriptionIssueStore } from '../data/subscription-issue-store.js';
+import { createListView } from './list.js';
+
+/**
+ * Read the labels of a group inside the status dropdown.
+ *
+ * @param {HTMLElement} mount - The container element.
+ * @param {string} group - `scope` or `status`.
+ * @returns {string[]}
+ */
+function groupLabels(mount, group) {
+  const dropdown = mount.querySelectorAll('.filter-dropdown')[0];
+  return Array.from(
+    dropdown.querySelectorAll(`.filter-dropdown__option--${group}`)
+  ).map((el) => (el.textContent || '').trim());
+}
+
+/**
+ * Click the scope radio with the given label.
+ *
+ * @param {HTMLElement} mount - The container element.
+ * @param {string} label - Visible label of the radio.
+ */
+function selectScope(mount, label) {
+  const dropdown = mount.querySelectorAll('.filter-dropdown')[0];
+  const option = Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--scope')
+  ).find((opt) => (opt.textContent || '').trim() === label);
+  const radio = /** @type {HTMLInputElement} */ (
+    option?.querySelector('input[type="radio"]')
+  );
+  radio.click();
+}
+
+/**
+ * Click the status checkbox with the given label.
+ *
+ * @param {HTMLElement} mount - The container element.
+ * @param {string} label - Visible label of the checkbox.
+ */
+function toggleStatus(mount, label) {
+  const dropdown = mount.querySelectorAll('.filter-dropdown')[0];
+  const option = Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--status')
+  ).find((opt) => (opt.textContent || '').trim() === label);
+  const checkbox = /** @type {HTMLInputElement} */ (
+    option?.querySelector('input[type="checkbox"]')
+  );
+  checkbox.click();
+}
+
+/**
+ * Read the status checkbox with the given label.
+ *
+ * @param {HTMLElement} mount - The container element.
+ * @param {string} label - Visible label of the checkbox.
+ * @returns {HTMLInputElement}
+ */
+function statusCheckbox(mount, label) {
+  const dropdown = mount.querySelectorAll('.filter-dropdown')[0];
+  const option = Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--status')
+  ).find((opt) => (opt.textContent || '').trim() === label);
+  return /** @type {HTMLInputElement} */ (
+    option?.querySelector('input[type="checkbox"]')
+  );
+}
+
+/**
+ * Read the scope radio with the given label.
+ *
+ * @param {HTMLElement} mount - The container element.
+ * @param {string} label - Visible label of the radio.
+ * @returns {HTMLInputElement}
+ */
+function scopeRadio(mount, label) {
+  const dropdown = mount.querySelectorAll('.filter-dropdown')[0];
+  const option = Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--scope')
+  ).find((opt) => (opt.textContent || '').trim() === label);
+  return /** @type {HTMLInputElement} */ (
+    option?.querySelector('input[type="radio"]')
+  );
+}
+
+/**
+ * Minimal store double recording the last `filters.status` written.
+ *
+ * @param {any} [initial_filters]
+ */
+function createTestStore(initial_filters) {
+  /** @type {any} */
+  const store = {
+    state: {
+      selected_id: null,
+      view: 'issues',
+      filters: initial_filters || { status: [], search: '', type: '' }
+    },
+    /** @type {((s: any) => void)[]} */
+    subs: [],
+    getState() {
+      return store.state;
+    },
+    /** @param {any} patch */
+    setState(patch) {
+      store.state = {
+        ...store.state,
+        ...(patch || {}),
+        filters: { ...store.state.filters, ...(patch.filters || {}) }
+      };
+      for (const fn of store.subs) {
+        fn(store.state);
+      }
+    },
+    /** @param {(s: any) => void} fn */
+    subscribe(fn) {
+      store.subs.push(fn);
+      return () => {
+        store.subs = store.subs.filter(
+          /** @param {(s: any) => void} f */ (f) => f !== fn
+        );
+      };
+    }
+  };
+  return store;
+}
+
+function createTestIssueStores() {
+  /** @type {Map<string, any>} */
+  const stores = new Map();
+  /** @type {Set<() => void>} */
+  const listeners = new Set();
+
+  /**
+   * @param {string} id
+   * @returns {any}
+   */
+  function getStore(id) {
+    let s = stores.get(id);
+    if (!s) {
+      s = createSubscriptionIssueStore(id);
+      stores.set(id, s);
+      s.subscribe(() => {
+        for (const fn of Array.from(listeners)) {
+          try {
+            fn();
+          } catch {
+            /* ignore */
+          }
+        }
+      });
+    }
+    return s;
+  }
+
+  return {
+    getStore,
+    /** @param {string} id */
+    snapshotFor(id) {
+      return getStore(id).snapshot().slice();
+    },
+    /** @param {() => void} fn */
+    subscribe(fn) {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    }
+  };
+}
+
+/**
+ * Mount a list view over the given issues.
+ *
+ * @param {any[]} issues - Issues delivered as the initial snapshot.
+ * @param {any} [store] - Optional state store double.
+ */
+async function mountList(issues, store) {
+  document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+  const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+  const issue_stores = createTestIssueStores();
+  issue_stores.getStore('tab:issues').applyPush({
+    type: 'snapshot',
+    id: 'tab:issues',
+    revision: 1,
+    issues
+  });
+  const view = createListView(
+    mount,
+    async () => [],
+    undefined,
+    store,
+    undefined,
+    issue_stores
+  );
+  await view.load();
+  return { mount, view, issue_stores };
+}
+
+/**
+ * Ids of the currently rendered rows.
+ *
+ * @param {HTMLElement} mount - The container element.
+ * @returns {string[]}
+ */
+function rowIds(mount) {
+  return Array.from(mount.querySelectorAll('tr.issue-row')).map(
+    (el) => el.getAttribute('data-issue-id') || ''
+  );
+}
+
+const ISSUES = [
+  { id: 'UI-1', title: 'Alpha', status: 'open', priority: 1 },
+  { id: 'UI-2', title: 'Beta', status: 'blocked', priority: 2 },
+  { id: 'UI-3', title: 'Gamma', status: 'in_progress', priority: 3 }
+];
+
+describe('views/list — status scope vs status filters', () => {
+  test('renders Ready as a scope radio, not a status checkbox', async () => {
+    const { mount } = await mountList(ISSUES);
+
+    const dropdown = mount.querySelectorAll('.filter-dropdown')[0];
+    const trigger = /** @type {HTMLButtonElement} */ (
+      dropdown.querySelector('.filter-dropdown__trigger')
+    );
+    trigger.click();
+
+    const menu = dropdown.querySelector('.filter-dropdown__menu');
+    expect(
+      Array.from(menu?.querySelectorAll('.filter-dropdown__group-label') || [])
+        .map((el) => (el.textContent || '').trim())
+        .join('|')
+    ).toBe('Scope|Status');
+    expect(menu?.querySelectorAll('.filter-dropdown__divider').length).toBe(1);
+    expect(groupLabels(mount, 'scope')).toEqual(['All issues', 'Ready only']);
+    expect(groupLabels(mount, 'status')).toEqual([
+      'Open',
+      'In progress',
+      'Blocked',
+      'Deferred',
+      'Closed',
+      'Pinned'
+    ]);
+  });
+
+  test('leaving the Ready scope for a status narrows to that status', async () => {
+    const store = createTestStore();
+    const { mount } = await mountList(ISSUES, store);
+
+    selectScope(mount, 'Ready only');
+    await Promise.resolve();
+    selectScope(mount, 'All issues');
+    await Promise.resolve();
+    toggleStatus(mount, 'Open');
+    await Promise.resolve();
+
+    expect(store.getState().filters.status).toEqual(['open']);
+    expect(rowIds(mount)).toEqual(['UI-1']);
+  });
+
+  test('a status toggle that reaches the Ready scope clears it', async () => {
+    const store = createTestStore();
+    const { mount } = await mountList(ISSUES, store);
+
+    selectScope(mount, 'Ready only');
+    await Promise.resolve();
+    // The checkbox is disabled in the UI, so no user can build a mixed
+    // selection this way; the handler still has to hold the invariant for the
+    // paths the UI does not gate (persisted state, another tab, the store).
+    const box = statusCheckbox(mount, 'Open');
+    box.dispatchEvent(new Event('change'));
+    await Promise.resolve();
+
+    expect(store.getState().filters.status).toEqual(['open']);
+    expect(scopeRadio(mount, 'All issues').checked).toBe(true);
+    expect(rowIds(mount)).toEqual(['UI-1']);
+  });
+
+  test('selecting the Ready scope clears the stored statuses', async () => {
+    const store = createTestStore();
+    const { mount } = await mountList(ISSUES, store);
+
+    toggleStatus(mount, 'Open');
+    await Promise.resolve();
+    toggleStatus(mount, 'Blocked');
+    await Promise.resolve();
+    selectScope(mount, 'Ready only');
+    await Promise.resolve();
+
+    expect(store.getState().filters.status).toEqual(['ready']);
+    expect(statusCheckbox(mount, 'Open').checked).toBe(false);
+    expect(statusCheckbox(mount, 'Blocked').checked).toBe(false);
+  });
+
+  test('disables the status checkboxes while Ready only is selected', async () => {
+    const { mount } = await mountList(ISSUES);
+
+    selectScope(mount, 'Ready only');
+    await Promise.resolve();
+
+    expect(statusCheckbox(mount, 'Open').disabled).toBe(true);
+    expect(statusCheckbox(mount, 'Closed').disabled).toBe(true);
+
+    selectScope(mount, 'All issues');
+    await Promise.resolve();
+
+    expect(statusCheckbox(mount, 'Open').disabled).toBe(false);
+  });
+
+  test('renders the union of several selected statuses', async () => {
+    const { mount } = await mountList(ISSUES);
+
+    toggleStatus(mount, 'Open');
+    await Promise.resolve();
+    toggleStatus(mount, 'Blocked');
+    await Promise.resolve();
+
+    expect(rowIds(mount)).toEqual(['UI-1', 'UI-2']);
+  });
+
+  test('drops the Ready scope from a mixed persisted selection', async () => {
+    const store = createTestStore({
+      status: ['ready', 'blocked'],
+      search: '',
+      type: ''
+    });
+
+    const { mount } = await mountList(ISSUES, store);
+
+    expect(rowIds(mount)).toEqual(['UI-2']);
+    expect(scopeRadio(mount, 'All issues').checked).toBe(true);
+    expect(statusCheckbox(mount, 'Blocked').checked).toBe(true);
+  });
+});

--- a/app/views/list.status-scope.test.js
+++ b/app/views/list.status-scope.test.js
@@ -231,7 +231,7 @@ describe('views/list — status scope vs status filters', () => {
         .join('|')
     ).toBe('Scope|Status');
     expect(menu?.querySelectorAll('.filter-dropdown__divider').length).toBe(1);
-    expect(groupLabels(mount, 'scope')).toEqual(['All issues', 'Ready only']);
+    expect(groupLabels(mount, 'scope')).toEqual(['By status', 'Ready only']);
     expect(groupLabels(mount, 'status')).toEqual([
       'Open',
       'In progress',
@@ -248,7 +248,7 @@ describe('views/list — status scope vs status filters', () => {
 
     selectScope(mount, 'Ready only');
     await Promise.resolve();
-    selectScope(mount, 'All issues');
+    selectScope(mount, 'By status');
     await Promise.resolve();
     toggleStatus(mount, 'Open');
     await Promise.resolve();
@@ -271,7 +271,7 @@ describe('views/list — status scope vs status filters', () => {
     await Promise.resolve();
 
     expect(store.getState().filters.status).toEqual(['open']);
-    expect(scopeRadio(mount, 'All issues').checked).toBe(true);
+    expect(scopeRadio(mount, 'By status').checked).toBe(true);
     expect(rowIds(mount)).toEqual(['UI-1']);
   });
 
@@ -300,7 +300,7 @@ describe('views/list — status scope vs status filters', () => {
     expect(statusCheckbox(mount, 'Open').disabled).toBe(true);
     expect(statusCheckbox(mount, 'Closed').disabled).toBe(true);
 
-    selectScope(mount, 'All issues');
+    selectScope(mount, 'By status');
     await Promise.resolve();
 
     expect(statusCheckbox(mount, 'Open').disabled).toBe(false);
@@ -327,7 +327,7 @@ describe('views/list — status scope vs status filters', () => {
     const { mount } = await mountList(ISSUES, store);
 
     expect(rowIds(mount)).toEqual(['UI-2']);
-    expect(scopeRadio(mount, 'All issues').checked).toBe(true);
+    expect(scopeRadio(mount, 'By status').checked).toBe(true);
     expect(statusCheckbox(mount, 'Blocked').checked).toBe(true);
   });
 });

--- a/app/views/list.test.js
+++ b/app/views/list.test.js
@@ -749,4 +749,75 @@ describe('views/list', () => {
     await Promise.resolve();
     expect(mount.querySelectorAll('tr.issue-row').length).toBe(2);
   });
+
+  test('status filter dropdown offers settable statuses plus Ready and Pinned, but not Hooked', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issueStores = createTestIssueStores();
+    issueStores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: []
+    });
+    const view = createListView(
+      mount,
+      async () => [],
+      undefined,
+      undefined,
+      undefined,
+      issueStores
+    );
+    await view.load();
+
+    const dropdown = mount.querySelectorAll('.filter-dropdown')[0];
+    const labels = Array.from(
+      dropdown.querySelectorAll('.filter-dropdown__option')
+    ).map((el) => (el.textContent || '').trim());
+    expect(labels).toEqual([
+      'Ready',
+      'Open',
+      'In progress',
+      'Blocked',
+      'Deferred',
+      'Closed',
+      'Pinned'
+    ]);
+    // Hooked is gate-managed (all-issues query lacks --include-gates), so it
+    // must not be an offered filter option even though it still renders a badge.
+    expect(labels).not.toContain('Hooked');
+  });
+
+  test('filters by a status that is not human-settable', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issues = [
+      { id: 'UI-1', title: 'Alpha', status: 'open', priority: 1 },
+      { id: 'UI-2', title: 'Beta', status: 'pinned', priority: 2 },
+      { id: 'UI-3', title: 'Gamma', status: 'deferred', priority: 3 }
+    ];
+    const issueStores = createTestIssueStores();
+    issueStores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues
+    });
+    const view = createListView(
+      mount,
+      async () => [],
+      undefined,
+      undefined,
+      undefined,
+      issueStores
+    );
+    await view.load();
+    expect(mount.querySelectorAll('tr.issue-row').length).toBe(3);
+
+    toggleFilter(mount, 0, 'Pinned');
+    await Promise.resolve();
+    const rows = mount.querySelectorAll('tr.issue-row');
+    expect(rows.length).toBe(1);
+    expect(rows[0].getAttribute('data-issue-id')).toBe('UI-2');
+  });
 });

--- a/app/views/list.test.js
+++ b/app/views/list.test.js
@@ -545,7 +545,7 @@ describe('views/list', () => {
     expect(mount.querySelectorAll('tr.issue-row').length).toBe(1);
 
     // Switch back to all; view should compose from all-issues membership
-    selectScope(mount, 'All issues');
+    selectScope(mount, 'By status');
     issueStores.getStore('tab:issues').applyPush({
       type: 'snapshot',
       id: 'tab:issues',
@@ -789,7 +789,7 @@ describe('views/list', () => {
 
     // Ready is a scope, not a status: it is a server-side membership and
     // cannot be unioned with the client-side status filter.
-    expect(labelsOf('scope')).toEqual(['All issues', 'Ready only']);
+    expect(labelsOf('scope')).toEqual(['By status', 'Ready only']);
     expect(labelsOf('status')).toEqual([
       'Open',
       'In progress',

--- a/app/views/list.test.js
+++ b/app/views/list.test.js
@@ -28,6 +28,27 @@ function toggleFilter(mount, dropdownIndex, optionText) {
 }
 
 /**
+ * Pick a scope radio in the status dropdown.
+ *
+ * @param {HTMLElement} mount - The container element
+ * @param {string} label - Visible label of the radio
+ */
+function selectScope(mount, label) {
+  const dropdown = mount.querySelectorAll('.filter-dropdown')[0];
+  const trigger = /** @type {HTMLButtonElement} */ (
+    dropdown.querySelector('.filter-dropdown__trigger')
+  );
+  trigger.click();
+  const option = Array.from(
+    dropdown.querySelectorAll('.filter-dropdown__option--scope')
+  ).find((opt) => (opt.textContent || '').trim() === label);
+  const radio = /** @type {HTMLInputElement} */ (
+    option?.querySelector('input[type="radio"]')
+  );
+  radio.click();
+}
+
+/**
  * Check if a filter option is checked in a dropdown.
  *
  * @param {HTMLElement} mount - The container element
@@ -334,11 +355,7 @@ describe('views/list', () => {
       issueStores
     );
     await view.load();
-    const statusSelect = /** @type {HTMLSelectElement} */ (
-      mount.querySelector('select')
-    );
-    statusSelect.value = 'ready';
-    statusSelect.dispatchEvent(new Event('change'));
+    selectScope(mount, 'Ready only');
     // switch subscription key and apply ready membership
     issueStores.getStore('tab:issues').applyPush({
       type: 'snapshot',
@@ -443,7 +460,7 @@ describe('views/list', () => {
     expect(isFilterChecked(mount, 1, 'Bug')).toBe(true);
   });
 
-  test('ready filter via select composes from push membership', async () => {
+  test('ready scope composes from push membership', async () => {
     document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
     const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
 
@@ -473,11 +490,7 @@ describe('views/list', () => {
     await view.load();
     expect(mount.querySelectorAll('tr.issue-row').length).toBe(2);
 
-    const select = /** @type {HTMLSelectElement} */ (
-      mount.querySelector('select')
-    );
-    select.value = 'ready';
-    select.dispatchEvent(new Event('change'));
+    selectScope(mount, 'Ready only');
     issueStores.getStore('tab:issues').applyPush({
       type: 'snapshot',
       id: 'tab:issues',
@@ -520,13 +533,8 @@ describe('views/list', () => {
     await view.load();
     expect(mount.querySelectorAll('tr.issue-row').length).toBe(2);
 
-    const select = /** @type {HTMLSelectElement} */ (
-      mount.querySelector('select')
-    );
-
     // Switch to ready (subscription now maps to ready-issues)
-    select.value = 'ready';
-    select.dispatchEvent(new Event('change'));
+    selectScope(mount, 'Ready only');
     issueStores.getStore('tab:issues').applyPush({
       type: 'snapshot',
       id: 'tab:issues',
@@ -537,8 +545,7 @@ describe('views/list', () => {
     expect(mount.querySelectorAll('tr.issue-row').length).toBe(1);
 
     // Switch back to all; view should compose from all-issues membership
-    select.value = 'all';
-    select.dispatchEvent(new Event('change'));
+    selectScope(mount, 'All issues');
     issueStores.getStore('tab:issues').applyPush({
       type: 'snapshot',
       id: 'tab:issues',
@@ -750,7 +757,7 @@ describe('views/list', () => {
     expect(mount.querySelectorAll('tr.issue-row').length).toBe(2);
   });
 
-  test('status filter dropdown offers settable statuses plus Ready and Pinned, but not Hooked', async () => {
+  test('status filter dropdown offers every status but Hooked, with Ready as a scope', async () => {
     document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
     const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
     const issueStores = createTestIssueStores();
@@ -771,11 +778,19 @@ describe('views/list', () => {
     await view.load();
 
     const dropdown = mount.querySelectorAll('.filter-dropdown')[0];
-    const labels = Array.from(
-      dropdown.querySelectorAll('.filter-dropdown__option')
-    ).map((el) => (el.textContent || '').trim());
-    expect(labels).toEqual([
-      'Ready',
+    /**
+     * @param {string} group
+     * @returns {string[]}
+     */
+    const labelsOf = (group) =>
+      Array.from(
+        dropdown.querySelectorAll(`.filter-dropdown__option--${group}`)
+      ).map((el) => (el.textContent || '').trim());
+
+    // Ready is a scope, not a status: it is a server-side membership and
+    // cannot be unioned with the client-side status filter.
+    expect(labelsOf('scope')).toEqual(['All issues', 'Ready only']);
+    expect(labelsOf('status')).toEqual([
       'Open',
       'In progress',
       'Blocked',
@@ -785,7 +800,7 @@ describe('views/list', () => {
     ]);
     // Hooked is gate-managed (all-issues query lacks --include-gates), so it
     // must not be an offered filter option even though it still renders a badge.
-    expect(labels).not.toContain('Hooked');
+    expect(labelsOf('status')).not.toContain('Hooked');
   });
 
   test('filters by a status that is not human-settable', async () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,7 +82,9 @@ Push‑only subscriptions for lists and details:
 Common message types (mutations only; list reads removed):
 
 - `update-status` payload:
-  `{ id: string, status: 'open'|'in_progress'|'closed' }`
+  `{ id: string, status: 'open'|'in_progress'|'blocked'|'deferred'|'closed' }`
+  (the human-settable statuses; `pinned` and `hooked` are bd's to manage and are
+  rejected)
 - `edit-text` payload:
   `{ id: string, field: 'title'|'description'|'acceptance'|'notes'|'design', value: string }`
 - `update-priority` payload: `{ id: string, priority: 0|1|2|3|4 }`
@@ -99,7 +101,8 @@ Removed in v2:
 ## UI → bd Command Mapping
 
 - Lists and details: push‑only via `subscribe-list` (no list reads)
-- Update status: `bd update <id> --status <open|in_progress|closed>`
+- Update status:
+  `bd update <id> --status <open|in_progress|blocked|deferred|closed>`
 - Update priority: `bd update <id> --priority <0..4>`
 - Edit title: `bd update <id> --title <text>`
 - Edit description: `bd update <id> --description <text>`
@@ -123,7 +126,16 @@ interface Issue {
   title?: string;
   description?: string;
   acceptance?: string;
-  status?: 'open' | 'in_progress' | 'closed';
+  // Read side: every status bd can report. Only the five human-settable ones
+  // are accepted by `update-status`.
+  status?:
+    | 'open'
+    | 'in_progress'
+    | 'blocked'
+    | 'deferred'
+    | 'closed'
+    | 'pinned'
+    | 'hooked';
   priority?: 0 | 1 | 2 | 3 | 4;
   dependencies?: Array<{
     id: string;

--- a/server/list-adapters.js
+++ b/server/list-adapters.js
@@ -23,6 +23,21 @@ export function mapSubscriptionToBdArgs(spec) {
     case 'blocked-issues': {
       return ['blocked', '--json'];
     }
+    case 'status-blocked-issues': {
+      // `bd blocked` reports only dependency-blocked issues (whose own status
+      // is `open`), so issues whose stored status is `blocked` need their own
+      // query. The Board's Blocked lane is the union of both.
+      // `--limit 0` = unlimited. Without it, `bd list` caps at its default 50.
+      return [
+        'list',
+        '--json',
+        '--tree=false',
+        '--status',
+        'blocked',
+        '--limit',
+        '0'
+      ];
+    }
     case 'ready-issues': {
       return ['ready', '--limit', '1000', '--json'];
     }

--- a/server/list-adapters.test.js
+++ b/server/list-adapters.test.js
@@ -61,6 +61,22 @@ describe('list adapters for subscription types', () => {
     ]);
   });
 
+  test('mapSubscriptionToBdArgs returns args for status-blocked-issues', () => {
+    const args = mapSubscriptionToBdArgs({ type: 'status-blocked-issues' });
+    // `bd blocked` only reports dependency-blocked issues, so issues whose
+    // stored status is `blocked` need their own list query.
+    // `--limit 0` = unlimited; without it bd list truncates at its default 50
+    expect(args).toEqual([
+      'list',
+      '--json',
+      '--tree=false',
+      '--status',
+      'blocked',
+      '--limit',
+      '0'
+    ]);
+  });
+
   test('mapSubscriptionToBdArgs returns args for issue-detail', () => {
     const args = mapSubscriptionToBdArgs({
       type: 'issue-detail',

--- a/server/validators.js
+++ b/server/validators.js
@@ -13,6 +13,7 @@ const SUBSCRIPTION_TYPES = new Set([
   'all-issues',
   'epics',
   'blocked-issues',
+  'status-blocked-issues',
   'ready-issues',
   'in-progress-issues',
   'closed-issues',

--- a/server/ws.js
+++ b/server/ws.js
@@ -5,7 +5,13 @@
  */
 import path from 'node:path';
 import { WebSocketServer } from 'ws';
-import { isRequest, makeError, makeOk } from '../app/protocol.js';
+import {
+  SETTABLE_STATUSES,
+  isRequest,
+  isSettableStatus,
+  makeError,
+  makeOk
+} from '../app/protocol.js';
 import { getGitUserName, runBd, runBdJson } from './bd.js';
 import { resolveWorkspaceDatabase } from './db.js';
 import { fetchListForSubscription } from './list-adapters.js';
@@ -782,19 +788,21 @@ export async function handleMessage(ws, data) {
   if (req.type === 'update-status') {
     log('update-status');
     const { id, status } = /** @type {any} */ (req.payload);
-    const allowed = new Set(['open', 'in_progress', 'closed']);
+    // Only human-settable statuses: `pinned` and `hooked` are bd's to manage.
     if (
       typeof id !== 'string' ||
       id.length === 0 ||
       typeof status !== 'string' ||
-      !allowed.has(status)
+      !isSettableStatus(status)
     ) {
       ws.send(
         JSON.stringify(
           makeError(
             req,
             'bad_request',
-            "payload requires { id: string, status: 'open'|'in_progress'|'closed' }"
+            `payload requires { id: string, status: ${SETTABLE_STATUSES.map(
+              (s) => `'${s}'`
+            ).join('|')} }`
           )
         )
       );

--- a/server/ws.list-subscriptions.test.js
+++ b/server/ws.list-subscriptions.test.js
@@ -268,6 +268,50 @@ describe('ws list subscriptions', () => {
     expect(ids).toEqual(['recent']);
   });
 
+  test('subscribe-list accepts status-blocked-issues', async () => {
+    const sock = {
+      sent: /** @type {string[]} */ ([]),
+      readyState: 1,
+      OPEN: 1,
+      /** @param {string} msg */
+      send(msg) {
+        this.sent.push(String(msg));
+      }
+    };
+
+    await handleMessage(
+      /** @type {any} */ (sock),
+      Buffer.from(
+        JSON.stringify({
+          id: 'sub-status-blocked',
+          type: /** @type {any} */ ('subscribe-list'),
+          payload: {
+            id: 'tab:board:status-blocked',
+            type: 'status-blocked-issues'
+          }
+        })
+      )
+    );
+
+    const last = sock.sent[sock.sent.length - 1];
+    const reply = JSON.parse(last);
+    // Without the validator allowlist entry this is rejected as bad_request
+    // and the Blocked lane silently stays empty.
+    expect(reply && reply.error).toBeUndefined();
+    expect(reply && reply.ok).toBe(true);
+
+    const snapshot_envelope = sock.sent
+      .map((m) => {
+        try {
+          return JSON.parse(m);
+        } catch {
+          return null;
+        }
+      })
+      .find((o) => o && o.type === 'snapshot');
+    expect(snapshot_envelope?.payload?.id).toBe('tab:board:status-blocked');
+  });
+
   test('subscribe-list rejects unknown subscription type', async () => {
     const sock = {
       sent: /** @type {string[]} */ ([]),

--- a/server/ws.mutations.test.js
+++ b/server/ws.mutations.test.js
@@ -46,6 +46,55 @@ describe('ws mutation handlers', () => {
     expect(obj.payload.status).toBe('in_progress');
   });
 
+  test('update-status accepts blocked and deferred', async () => {
+    for (const status of ['blocked', 'deferred']) {
+      const mRun = /** @type {import('vitest').Mock} */ (runBd);
+      const mJson = /** @type {import('vitest').Mock} */ (runBdJson);
+      mRun.mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+      mJson.mockResolvedValueOnce({
+        code: 0,
+        stdoutJson: { id: 'UI-7', status }
+      });
+      const ws = makeStubSocket();
+      const req = {
+        id: `r-${status}`,
+        type: 'update-status',
+        payload: { id: 'UI-7', status }
+      };
+      await handleMessage(
+        /** @type {any} */ (ws),
+        Buffer.from(JSON.stringify(req))
+      );
+      const obj = JSON.parse(ws.sent[ws.sent.length - 1]);
+      expect(obj.ok).toBe(true);
+      expect(obj.payload.status).toBe(status);
+      expect(mRun.mock.calls[mRun.mock.calls.length - 1][0]).toEqual([
+        'update',
+        'UI-7',
+        '--status',
+        status
+      ]);
+    }
+  });
+
+  test('update-status rejects machine-managed statuses', async () => {
+    for (const status of ['pinned', 'hooked']) {
+      const ws = makeStubSocket();
+      const req = {
+        id: `r-${status}`,
+        type: 'update-status',
+        payload: { id: 'UI-7', status }
+      };
+      await handleMessage(
+        /** @type {any} */ (ws),
+        Buffer.from(JSON.stringify(req))
+      );
+      const obj = JSON.parse(ws.sent[ws.sent.length - 1]);
+      expect(obj.ok).toBe(false);
+      expect(obj.error.code).toBe('bad_request');
+    }
+  });
+
   test('update-status invalid payload yields bad_request', async () => {
     const ws = makeStubSocket();
     const req = {

--- a/types/subscriptions.ts
+++ b/types/subscriptions.ts
@@ -41,7 +41,10 @@ export interface DependencyRef {
 export type SubscriptionType =
   | 'all-issues'
   | 'epics'
+  /** Dependency-blocked issues (`bd blocked`); their own status is `open`. */
   | 'blocked-issues'
+  /** Issues whose stored status is `blocked` (`bd list --status blocked`). */
+  | 'status-blocked-issues'
   | 'ready-issues'
   | 'in-progress-issues'
   | 'closed-issues'


### PR DESCRIPTION
**Depends on #99.** Merge that first, or the new Deferred filter returns an empty list. Details at the bottom.

bdui knows three of bd's seven statuses. bd will tell you the rest itself:

```
$ bd list --status bogus --json
invalid status "bogus" (valid: open, in_progress, blocked, deferred, closed, pinned, hooked)
```

Set an issue to `deferred` from the CLI and the UI gives you a white unstyled badge, won't let you filter to it, and won't let you set it back. Same for `blocked`.

The root cause is that `STATUSES` in `app/utils/status.js` was dead code. Nothing imported it. Three separate views hard-coded `['open','in_progress','closed']` inline instead, which is how they drifted apart in the first place. It's still happening: #91 re-introduces the same narrow union in `app/data/providers.js`.

## Render everything, offer only what a human should set

Two lists, because the seven statuses aren't peers.

`STATUSES` holds all seven and drives labels and badge CSS. Anything bd can emit has to render correctly.

`SETTABLE_STATUSES` holds the five human workflow states (`open`, `in_progress`, `blocked`, `deferred`, `closed`) and drives the editable dropdowns. `pinned` and `hooked` belong to bd's own machinery: `pinned` has `--pinned`/`--no-pinned` list filters, and `hooked` is tied to the gate/formula engine. Letting someone hand-set those from a dropdown would desync it. So the UI renders them and refuses to set them.

The status filter offers `ready` plus all seven, so you can filter to anything that can exist.

## Why the constants live in `app/protocol.js`

`server/ws.js` had its own hard-coded allowlist, `new Set(['open','in_progress','closed'])`. Without widening it, picking "Blocked" in the new dropdown round-trips to a `bad_request` and the whole feature is cosmetic.

But `server/ws.js` can't import from `app/utils/`. The `files` array in `package.json` ships only `app/protocol.js` out of `app/`, so an npm-installed package would crash on the missing module. `protocol.js` is already the module both sides share, and the settable set genuinely is part of the `update-status` contract. `app/utils/status.js` re-exports both constants, so client code still imports them from where you'd expect.

A single `isSettableStatus()` guard now gates both the option's `disabled` attribute and the server's validation. The client can't offer what the server would reject.

## Colours

`blocked` is red, since it's the only status that means something is wrong. `deferred` is a muted blue-grey: present but recessive. `pinned` reuses the palette's existing amber accent. `hooked` renders as an unfilled pill with a dashed border instead of taking a new hue, because every remaining hue collided with something at the actual mix, and an outline says "machine-managed, recedes" better than another colour does.

## Known, and deliberately out of scope

The Board tab's "Blocked" column means dependency-blocked (it comes from `bd blocked`), not `status === 'blocked'`. Now that `blocked` is a real status in the UI, the word means two different things in two views, and dropping a card into that column still sets `open`. I left the board alone rather than widen this PR, but it wants a decision.

`bd list` hides gate issues unless you pass `--include-gates`. If `hooked` issues are always gate-type, then the Hooked filter option is dead by construction. I couldn't verify this, having no hooked issues to test against. Happy to drop the option if you know it's dead.

`createStatusBadge` in `app/utils/status-badge.js` has no importers. It held a second private copy of the label switch, which would have rendered `deferred` as "Unknown" even after `status.js` was fixed, so I deleted the duplicate and delegated to `statusLabel`. Removing the module outright felt like a separate PR.

One pre-existing mismatch worth knowing about, since this PR rewrites the typedef: `app/state.js` types `StatusFilter` as a scalar, but `list.js` writes an array, so the persisted status filter never survives a reload. I didn't touch it.

`statusLabel('')` now returns "Unknown" rather than "Open". An unknown status quietly presenting as Open is a footgun, and nothing relied on the old behaviour.

## On the #99 dependency

`computeIssuesSpec` maps the status filter to a server-side subscription and only knows three of them. Everything else, `deferred` included, falls through to the `all-issues` subscription. On `main` that query passes no `--limit`, so it inherits bd's default of 50, and bd sorts by priority. Deferred and blocked issues are exactly the low-priority tail that falls past the cut, so the filter this PR adds would return nothing on any workspace over ~50 issues.

#99 fixes that in one line. It's worth merging on its own regardless, but this PR needs it.

`npm run all` is green: 298 tests, plus eslint, tsc and prettier.
