### PR TITLE
feat(views): resizable table columns and epics search

### DIFF
--- a/app/styles.css
+++ b/app/styles.css
@@ -1004,7 +1004,7 @@ input.inline-edit:focus {
   box-shadow: none;
 }
 
-#list-panel .panel__header input[type='search'] {
+.panel__header input[type='search'] {
   flex: 1;
 }
 
@@ -1144,7 +1144,8 @@ input.inline-edit:focus {
   border: 1px solid var(--border);
   border-radius: 6px;
   margin: 0px 12px;
-  overflow: hidden;
+  /* Scroll horizontally when resized columns exceed the panel width */
+  overflow: auto;
   background: var(--bg);
 }
 .epic-header {
@@ -1169,6 +1170,8 @@ input.inline-edit:focus {
 }
 .epic-children {
   padding: 8px 12px 12px;
+  /* Scroll horizontally when resized columns exceed the panel width */
+  overflow-x: auto;
 }
 .table {
   width: 100%;
@@ -1183,6 +1186,9 @@ input.inline-edit:focus {
   }
   /* Ensure form controls fill the cell */
   td {
+    /* Clip cell content instead of spilling into the next column */
+    overflow: hidden;
+
     input[type='text'],
     select {
       width: 100%;
@@ -1192,12 +1198,65 @@ input.inline-edit:focus {
       display: block;
       width: 100%;
     }
+    /* Truncate instead of spilling into the next column when narrowed */
+    .id-copy {
+      display: block;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
   th {
     font-size: 12px;
     color: var(--muted);
     font-weight: 600;
+    /* Anchor for the absolutely positioned resize handle */
+    position: relative;
   }
+  /* Trailing column that absorbs the space left by fixed column widths */
+  th.col-spacer,
+  td.col-spacer {
+    padding: 0;
+  }
+}
+
+/* Column resizing */
+.col-resizer {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  /* Straddle the column boundary; half sits over the next column */
+  right: calc(var(--space-4) / -2);
+  width: var(--space-4);
+  cursor: col-resize;
+  touch-action: none;
+  user-select: none;
+  z-index: 1;
+}
+.col-resizer::after {
+  content: '';
+  position: absolute;
+  top: 15%;
+  bottom: 15%;
+  left: 50%;
+  width: 1px;
+  transform: translateX(-50%);
+  background: var(--border);
+  transition: background 120ms ease;
+}
+.col-resizer:hover::after,
+.col-resizer:focus-visible::after,
+body.is-col-resizing .col-resizer:active::after {
+  width: 2px;
+  background: var(--link);
+}
+.col-resizer:focus-visible {
+  outline: none;
+}
+/* Keep the drag cursor and suppress selection for the whole drag */
+body.is-col-resizing {
+  cursor: col-resize;
+  user-select: none;
 }
 .epic-row:hover {
   background: color-mix(in srgb, var(--control-bg) 55%, transparent);

--- a/app/views/column-resize.js
+++ b/app/views/column-resize.js
@@ -1,0 +1,330 @@
+import { html } from 'lit-html';
+
+/**
+ * Resizable table columns shared by the issues and epics tables.
+ *
+ * Widths are stored per view in localStorage. Content columns carry an
+ * explicit pixel width; one column may stay `null` (auto) so the table keeps
+ * filling its container. A trailing spacer column absorbs the leftover space
+ * once every content column has an explicit width.
+ */
+
+/**
+ * @typedef {Object} ColumnSpec
+ * @property {string} key - Stable column key.
+ * @property {string} label - Header label.
+ * @property {number} width - Default width in pixels.
+ * @property {boolean} [flex] - Column stretches to fill the row by default.
+ * @property {number} [min] - Minimum width in pixels.
+ */
+
+const MIN_COLUMN_WIDTH = 48;
+const MAX_COLUMN_WIDTH = 1000;
+const KEYBOARD_STEP = 16;
+
+/**
+ * Clamp a width to the allowed range for a column.
+ *
+ * @param {number} px
+ * @param {ColumnSpec} column
+ */
+function clampWidth(px, column) {
+  const min = typeof column.min === 'number' ? column.min : MIN_COLUMN_WIDTH;
+  return Math.max(min, Math.min(MAX_COLUMN_WIDTH, Math.round(px)));
+}
+
+/**
+ * Default width of a single column (`null` for the auto sizing column).
+ *
+ * @param {ColumnSpec} column
+ * @returns {number | null}
+ */
+function defaultWidth(column) {
+  return column.flex ? null : column.width;
+}
+
+/**
+ * Default widths for all columns.
+ *
+ * @param {ColumnSpec[]} columns
+ * @returns {(number | null)[]}
+ */
+function defaultWidths(columns) {
+  return columns.map((column) => defaultWidth(column));
+}
+
+/**
+ * Read persisted widths, falling back to defaults for missing or invalid
+ * entries.
+ *
+ * @param {string} storage_key
+ * @param {ColumnSpec[]} columns
+ * @returns {(number | null)[]}
+ */
+function loadWidths(storage_key, columns) {
+  try {
+    const raw = window.localStorage.getItem(storage_key);
+    if (!raw) {
+      return defaultWidths(columns);
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed) || parsed.length !== columns.length) {
+      return defaultWidths(columns);
+    }
+    return columns.map((column, index) => {
+      const value = parsed[index];
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return defaultWidth(column);
+      }
+      return clampWidth(value, column);
+    });
+  } catch {
+    return defaultWidths(columns);
+  }
+}
+
+/**
+ * Trailing spacer cell for a body row. Keeps body rows aligned with the
+ * spacer column declared by `createColumnResizer().colgroup()`.
+ */
+export function columnSpacerCell() {
+  return html`<td class="col-spacer" aria-hidden="true"></td>`;
+}
+
+/**
+ * Create resizable column support for the `.table` elements rendered inside
+ * `mount_element`. All tables in the mount share one set of widths, so the
+ * epics view keeps its per-epic tables aligned.
+ *
+ * @param {Object} options
+ * @param {HTMLElement} options.mount_element - Element the tables render into.
+ * @param {string} options.storage_key - localStorage key for persisted widths.
+ * @param {ColumnSpec[]} options.columns - Column definitions, in cell order.
+ * @param {() => void} options.requestRender - Re-render the owning view.
+ */
+export function createColumnResizer(options) {
+  const mount_element = options.mount_element;
+  const storage_key = options.storage_key;
+  const columns = options.columns;
+  const requestRender = options.requestRender;
+  /** @type {(number | null)[]} */
+  let widths = loadWidths(storage_key, columns);
+  /** @type {null | (() => void)} */
+  let endDrag = null;
+
+  function persist() {
+    try {
+      window.localStorage.setItem(storage_key, JSON.stringify(widths));
+    } catch {
+      // Storage unavailable; widths remain in memory for this session.
+    }
+  }
+
+  /**
+   * Width the spacer column should use: it only stretches once every content
+   * column has an explicit width.
+   *
+   * @param {(number | null)[]} next_widths
+   */
+  function spacerWidth(next_widths) {
+    return next_widths.some((w) => w === null) ? '0' : '';
+  }
+
+  /**
+   * Rendered width of a column, used as the starting point of a resize.
+   *
+   * @param {number} index
+   * @param {HTMLElement | null} cell
+   */
+  function currentWidth(index, cell) {
+    if (cell) {
+      const rect = cell.getBoundingClientRect();
+      if (rect.width > 0) {
+        return rect.width;
+      }
+    }
+    const stored = widths[index];
+    return typeof stored === 'number' ? stored : columns[index].width;
+  }
+
+  /**
+   * Apply a width to every table in the mount without a full re-render so
+   * dragging stays smooth.
+   *
+   * @param {number} index
+   * @param {number} px
+   */
+  function applyLiveWidth(index, px) {
+    const next_widths = widths.map((w, i) => (i === index ? px : w));
+    const tables = Array.from(mount_element.querySelectorAll('table.table'));
+    for (const table of tables) {
+      const cols = /** @type {HTMLElement[]} */ (
+        Array.from(table.querySelectorAll('colgroup > col'))
+      );
+      const col_element = cols[index];
+      if (col_element) {
+        col_element.style.width = `${px}px`;
+      }
+      const spacer_element = cols[columns.length];
+      if (spacer_element) {
+        spacer_element.style.width = spacerWidth(next_widths);
+      }
+    }
+  }
+
+  /**
+   * Store a new width for a column and re-render.
+   *
+   * @param {number} index
+   * @param {number | null} px
+   */
+  function commitWidth(index, px) {
+    widths = widths.map((w, i) => (i === index ? px : w));
+    persist();
+    requestRender();
+  }
+
+  /**
+   * Start a drag resize.
+   *
+   * @param {MouseEvent} ev
+   * @param {number} index
+   */
+  function onPointerDown(ev, index) {
+    if (ev.button !== 0) {
+      return;
+    }
+    ev.preventDefault();
+    ev.stopPropagation();
+    if (endDrag) {
+      endDrag();
+    }
+    const handle = /** @type {HTMLElement} */ (ev.currentTarget);
+    const cell = /** @type {HTMLElement | null} */ (handle.closest('th'));
+    const column = columns[index];
+    const start_x = ev.clientX;
+    const start_width = currentWidth(index, cell);
+    let next_width = clampWidth(start_width, column);
+
+    /** @param {MouseEvent} move_ev */
+    const onPointerMove = (move_ev) => {
+      next_width = clampWidth(
+        start_width + (move_ev.clientX - start_x),
+        column
+      );
+      applyLiveWidth(index, next_width);
+    };
+    const onPointerUp = () => {
+      if (endDrag) {
+        endDrag();
+      }
+      commitWidth(index, next_width);
+    };
+    endDrag = () => {
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerUp);
+      window.removeEventListener('pointercancel', onPointerUp);
+      document.body.classList.remove('is-col-resizing');
+      endDrag = null;
+    };
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('pointercancel', onPointerUp);
+    document.body.classList.add('is-col-resizing');
+  }
+
+  /**
+   * Resize with the keyboard while the handle is focused.
+   *
+   * @param {KeyboardEvent} ev
+   * @param {number} index
+   */
+  function onKeyDown(ev, index) {
+    if (ev.key !== 'ArrowLeft' && ev.key !== 'ArrowRight') {
+      return;
+    }
+    ev.preventDefault();
+    ev.stopPropagation();
+    const handle = /** @type {HTMLElement} */ (ev.currentTarget);
+    const cell = /** @type {HTMLElement | null} */ (handle.closest('th'));
+    const column = columns[index];
+    const delta = ev.key === 'ArrowRight' ? KEYBOARD_STEP : -KEYBOARD_STEP;
+    commitWidth(index, clampWidth(currentWidth(index, cell) + delta, column));
+  }
+
+  /**
+   * Restore a column to its default width.
+   *
+   * @param {number} index
+   */
+  function resetColumn(index) {
+    commitWidth(index, defaultWidth(columns[index]));
+  }
+
+  return {
+    /**
+     * Render the `<colgroup>` of a resizable table.
+     */
+    colgroup() {
+      return html`<colgroup>
+        ${widths.map((w) =>
+          w === null ? html`<col />` : html`<col style="width: ${w}px" />`
+        )}
+        <col
+          class="col-spacer"
+          style=${spacerWidth(widths) ? 'width: 0' : ''}
+        />
+      </colgroup>`;
+    },
+
+    /**
+     * Render the header cells, each with a resize handle.
+     */
+    headerCells() {
+      return html`${columns.map(
+          (column, index) =>
+            html`<th role="columnheader" scope="col">
+              <span class="text-truncate">${column.label}</span>
+              <span
+                class="col-resizer"
+                role="separator"
+                aria-orientation="vertical"
+                aria-label="Resize ${column.label} column"
+                title="Drag to resize, double-click to reset"
+                tabindex="0"
+                @pointerdown=${
+                  /** @param {Event} e */ (e) =>
+                    onPointerDown(/** @type {MouseEvent} */ (e), index)
+                }
+                @keydown=${
+                  /** @param {Event} e */ (e) =>
+                    onKeyDown(/** @type {KeyboardEvent} */ (e), index)
+                }
+                @dblclick=${
+                  /** @param {Event} e */ (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    resetColumn(index);
+                  }
+                }
+                @click=${/** @param {Event} e */ (e) => e.stopPropagation()}
+              ></span>
+            </th>`
+        )}
+        <th class="col-spacer" aria-hidden="true"></th>`;
+    },
+
+    /**
+     * Current widths, `null` for auto sized columns.
+     */
+    widths() {
+      return widths.slice();
+    },
+
+    destroy() {
+      if (endDrag) {
+        endDrag();
+      }
+    }
+  };
+}

--- a/app/views/column-resize.test.js
+++ b/app/views/column-resize.test.js
@@ -1,0 +1,282 @@
+import { html, render } from 'lit-html';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { columnSpacerCell, createColumnResizer } from './column-resize.js';
+
+/**
+ * @import { ColumnSpec } from './column-resize.js'
+ */
+
+const STORAGE_KEY = 'test.columns';
+
+/** @type {ColumnSpec[]} */
+const COLUMNS = [
+  { key: 'id', label: 'ID', width: 100 },
+  { key: 'title', label: 'Title', width: 320, flex: true },
+  { key: 'status', label: 'Status', width: 120 }
+];
+
+/**
+ * Render one or more resizable tables sharing a single resizer.
+ *
+ * @param {number} [table_count]
+ */
+function setup(table_count = 1) {
+  document.body.innerHTML = '<div id="mount"></div>';
+  const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+  const resizer = createColumnResizer({
+    mount_element: mount,
+    storage_key: STORAGE_KEY,
+    columns: COLUMNS,
+    requestRender: () => doRender()
+  });
+
+  function doRender() {
+    render(
+      html`${Array.from(
+        { length: table_count },
+        () =>
+          html`<table class="table">
+            ${resizer.colgroup()}
+            <thead>
+              <tr>
+                ${resizer.headerCells()}
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>1</td>
+                <td>2</td>
+                <td>3</td>
+                ${columnSpacerCell()}
+              </tr>
+            </tbody>
+          </table>`
+      )}`,
+      mount
+    );
+  }
+
+  doRender();
+  return { mount, resizer };
+}
+
+/**
+ * Widths of the rendered `<col>` elements of the nth table.
+ *
+ * @param {HTMLElement} mount
+ * @param {number} [table_index]
+ */
+function colWidths(mount, table_index = 0) {
+  const table = mount.querySelectorAll('table.table')[table_index];
+  return Array.from(table.querySelectorAll('colgroup > col')).map(
+    (col) => /** @type {HTMLElement} */ (col).style.width
+  );
+}
+
+/**
+ * Drag the resize handle of a column by `dx` pixels.
+ *
+ * @param {HTMLElement} mount
+ * @param {number} index
+ * @param {number} dx
+ * @param {{ drop?: boolean }} [options]
+ */
+function drag(mount, index, dx, options = {}) {
+  const handle = mount.querySelectorAll('.col-resizer')[index];
+  handle.dispatchEvent(
+    new MouseEvent('pointerdown', { clientX: 500, bubbles: true })
+  );
+  window.dispatchEvent(new MouseEvent('pointermove', { clientX: 500 + dx }));
+  if (options.drop !== false) {
+    window.dispatchEvent(new MouseEvent('pointerup', {}));
+  }
+}
+
+describe('views/column-resize', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('renders a col per column plus a trailing spacer', () => {
+    const { mount } = setup();
+
+    const widths = colWidths(mount);
+
+    expect(widths).toEqual(['100px', '', '120px', '0px']);
+  });
+
+  test('renders a resize handle in every header cell', () => {
+    const { mount } = setup();
+
+    const handles = mount.querySelectorAll('th .col-resizer');
+
+    expect(handles.length).toBe(COLUMNS.length);
+    expect(handles[0].getAttribute('aria-label')).toBe('Resize ID column');
+  });
+
+  test('renders a spacer cell in header and body rows', () => {
+    const { mount } = setup();
+
+    const spacers = mount.querySelectorAll('.col-spacer');
+
+    expect(spacers.length).toBe(3);
+  });
+
+  test('widens a column on drag', () => {
+    const { mount, resizer } = setup();
+
+    drag(mount, 0, 60);
+
+    expect(resizer.widths()).toEqual([160, null, 120]);
+    expect(colWidths(mount)[0]).toBe('160px');
+  });
+
+  test('narrows a column on drag', () => {
+    const { mount, resizer } = setup();
+
+    drag(mount, 2, -20);
+
+    expect(resizer.widths()).toEqual([100, null, 100]);
+  });
+
+  test('clamps a column to the minimum width', () => {
+    const { mount, resizer } = setup();
+
+    drag(mount, 0, -400);
+
+    expect(resizer.widths()).toEqual([48, null, 120]);
+  });
+
+  test('updates the column while dragging, before the drop', () => {
+    const { mount, resizer } = setup();
+
+    drag(mount, 0, 40, { drop: false });
+
+    expect(colWidths(mount)[0]).toBe('140px');
+    expect(resizer.widths()).toEqual([100, null, 120]);
+  });
+
+  test('keeps all tables in the mount in sync while dragging', () => {
+    const { mount } = setup(2);
+
+    drag(mount, 0, 40, { drop: false });
+
+    expect(colWidths(mount, 1)[0]).toBe('140px');
+  });
+
+  test('gives the auto column an explicit width when resized', () => {
+    const { mount, resizer } = setup();
+    const cell = /** @type {HTMLElement} */ (mount.querySelectorAll('th')[1]);
+    cell.getBoundingClientRect = () =>
+      /** @type {DOMRect} */ (/** @type {unknown} */ ({ width: 300 }));
+
+    drag(mount, 1, 25);
+
+    expect(resizer.widths()).toEqual([100, 325, 120]);
+  });
+
+  test('stretches the spacer column once no column is auto sized', () => {
+    const { mount } = setup();
+
+    drag(mount, 1, 10);
+
+    expect(colWidths(mount)[3]).toBe('');
+  });
+
+  test('resizes with the arrow keys', () => {
+    const { mount, resizer } = setup();
+    const handle = mount.querySelectorAll('.col-resizer')[0];
+
+    handle.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })
+    );
+    handle.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })
+    );
+
+    expect(resizer.widths()).toEqual([132, null, 120]);
+  });
+
+  test('ignores unrelated keys on the resize handle', () => {
+    const { mount, resizer } = setup();
+    const handle = mount.querySelectorAll('.col-resizer')[0];
+
+    handle.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    );
+
+    expect(resizer.widths()).toEqual([100, null, 120]);
+  });
+
+  test('restores the default width on double click', () => {
+    const { mount, resizer } = setup();
+    drag(mount, 0, 60);
+
+    mount
+      .querySelectorAll('.col-resizer')[0]
+      .dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+
+    expect(resizer.widths()).toEqual([100, null, 120]);
+  });
+
+  test('restores auto sizing of the flex column on double click', () => {
+    const { mount, resizer } = setup();
+    drag(mount, 1, 20);
+
+    mount
+      .querySelectorAll('.col-resizer')[1]
+      .dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+
+    expect(resizer.widths()).toEqual([100, null, 120]);
+  });
+
+  test('persists widths to local storage', () => {
+    const { mount } = setup();
+
+    drag(mount, 0, 60);
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('[160,null,120]');
+  });
+
+  test('restores persisted widths', () => {
+    window.localStorage.setItem(STORAGE_KEY, '[200,null,90]');
+
+    const { mount } = setup();
+
+    expect(colWidths(mount)).toEqual(['200px', '', '90px', '0px']);
+  });
+
+  test('clamps persisted widths to the allowed range', () => {
+    window.localStorage.setItem(STORAGE_KEY, '[5,null,5000]');
+
+    const { resizer } = setup();
+
+    expect(resizer.widths()).toEqual([48, null, 1000]);
+  });
+
+  test('falls back to defaults for a stale column count', () => {
+    window.localStorage.setItem(STORAGE_KEY, '[200,300]');
+
+    const { resizer } = setup();
+
+    expect(resizer.widths()).toEqual([100, null, 120]);
+  });
+
+  test('falls back to defaults for invalid stored data', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'not json');
+
+    const { resizer } = setup();
+
+    expect(resizer.widths()).toEqual([100, null, 120]);
+  });
+
+  test('stops tracking pointer moves after destroy', () => {
+    const { mount, resizer } = setup();
+    drag(mount, 0, 40, { drop: false });
+
+    resizer.destroy();
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 900 }));
+
+    expect(colWidths(mount)[0]).toBe('140px');
+  });
+});

--- a/app/views/epics.js
+++ b/app/views/epics.js
@@ -1,11 +1,24 @@
 import { html, render } from 'lit-html';
 import { createListSelectors } from '../data/list-selectors.js';
+import { cmpPriorityThenCreated } from '../data/sort.js';
 import { createIssueIdRenderer } from '../utils/issue-id-renderer.js';
-import { createIssueRowRenderer } from './issue-row.js';
+import { createColumnResizer } from './column-resize.js';
+import { ISSUE_ROW_COLUMNS, createIssueRowRenderer } from './issue-row.js';
 
 /**
- * @typedef {{ id: string, title?: string, status?: string, priority?: number, issue_type?: string, assignee?: string, created_at?: number, updated_at?: number }} IssueLite
+ * @typedef {{ id: string, title?: string, status?: 'open'|'in_progress'|'closed', priority?: number, issue_type?: string, assignee?: string, parent?: string, created_at?: number, updated_at?: number }} IssueLite
  */
+
+/**
+ * Lists backing the child issue search. Subscribed only while a search term is
+ * active; together they cover the same issues an expanded epic shows.
+ *
+ * @type {{ client_id: string, spec: { type: string } }[]}
+ */
+const SEARCH_LISTS = [
+  { client_id: 'epics:search-open', spec: { type: 'all-issues' } },
+  { client_id: 'epics:search-closed', spec: { type: 'closed-issues' } }
+];
 
 /**
  * Epics view (push-only):
@@ -14,6 +27,7 @@ import { createIssueRowRenderer } from './issue-row.js';
  * - On expand, subscribes to `detail:{id}` (issue-detail) for the epic.
  * - Renders children from the epic detail's `dependents` list.
  * - Provides inline edits via mutations; UI re-renders on push.
+ * - Search matches epics by id/title and their child issues by id/title.
  *
  * @param {HTMLElement} mount_element
  * @param {{ updateIssue: (input: any) => Promise<any> }} data
@@ -30,12 +44,17 @@ export function createEpicsView(
 ) {
   /** @type {any[]} */
   let groups = [];
+  /** @type {string} */
+  let search_text = loadSearch();
   /** @type {Set<string>} */
   const expanded = new Set();
   /** @type {Set<string>} */
   const loading = new Set();
   /** @type {Map<string, () => Promise<void>>} */
   const epic_unsubs = new Map();
+  /** @type {Map<string, () => Promise<void>>} */
+  const search_unsubs = new Map();
+  let search_loading = false;
   // Centralized selection helpers
   const selectors = issue_stores ? createListSelectors(issue_stores) : null;
   // Live re-render on pushes: recompute groups when stores change
@@ -46,10 +65,7 @@ export function createEpicsView(
       doRender();
       // Auto-expand first epic when transitioning from empty to non-empty
       if (had_none && groups.length > 0) {
-        const first_id = String(groups[0].epic?.id || '');
-        if (first_id && !expanded.has(first_id)) {
-          void toggle(first_id);
-        }
+        void expandFirst();
       }
     });
   }
@@ -63,27 +79,244 @@ export function createEpicsView(
     row_class: 'epic-row'
   });
 
+  // Resizable columns shared by every epic table, persisted per view
+  const column_resizer = createColumnResizer({
+    mount_element,
+    storage_key: 'beads-ui.columns.epics',
+    columns: ISSUE_ROW_COLUMNS,
+    requestRender: doRender
+  });
+
   function doRender() {
     render(template(), mount_element);
   }
 
-  function template() {
-    if (!groups.length) {
-      return html`<div class="panel__header muted">No epics found.</div>`;
+  /**
+   * Read the persisted search term.
+   */
+  function loadSearch() {
+    try {
+      return window.localStorage.getItem('beads-ui.epics.search') || '';
+    } catch {
+      return '';
     }
-    return html`${groups.map((g) => groupTemplate(g))}`;
+  }
+
+  /**
+   * Event: search input.
+   *
+   * @param {Event} ev
+   */
+  function onSearchInput(ev) {
+    const input = /** @type {HTMLInputElement} */ (ev.currentTarget);
+    search_text = input.value;
+    try {
+      window.localStorage.setItem('beads-ui.epics.search', search_text);
+    } catch {
+      // Storage unavailable; the term stays in memory for this session.
+    }
+    doRender();
+    void syncSearchSubscriptions();
+  }
+
+  /**
+   * Subscribe to the issue lists backing child search while a term is active;
+   * release them when the search is cleared.
+   */
+  async function syncSearchSubscriptions() {
+    const wanted = search_text.length > 0;
+    if (!subscriptions || typeof subscriptions.subscribeList !== 'function') {
+      return;
+    }
+    if (wanted && search_unsubs.size === 0 && !search_loading) {
+      search_loading = true;
+      doRender();
+      for (const list of SEARCH_LISTS) {
+        try {
+          // Register the store first to avoid dropping the initial snapshot
+          if (issue_stores && /** @type {any} */ (issue_stores).register) {
+            /** @type {any} */ (issue_stores).register(
+              list.client_id,
+              list.spec
+            );
+          }
+          const unsub = await subscriptions.subscribeList(
+            list.client_id,
+            list.spec
+          );
+          search_unsubs.set(list.client_id, unsub);
+        } catch {
+          // ignore subscription failures; search falls back to epic matches
+        }
+      }
+      search_loading = false;
+      doRender();
+      if (!search_text) {
+        // Search was cleared while subscribing; release right away
+        await syncSearchSubscriptions();
+      }
+      return;
+    }
+    if (!wanted && search_unsubs.size > 0) {
+      const entries = Array.from(search_unsubs.entries());
+      search_unsubs.clear();
+      for (const [client_id, unsub] of entries) {
+        try {
+          await unsub();
+        } catch {
+          // ignore
+        }
+        try {
+          if (issue_stores && /** @type {any} */ (issue_stores).unregister) {
+            /** @type {any} */ (issue_stores).unregister(client_id);
+          }
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }
+
+  /**
+   * Child issues of every epic, keyed by parent id, from the search lists.
+   *
+   * @returns {Map<string, IssueLite[]>}
+   */
+  function childrenByParent() {
+    /** @type {Map<string, IssueLite[]>} */
+    const by_parent = new Map();
+    if (!issue_stores || typeof issue_stores.snapshotFor !== 'function') {
+      return by_parent;
+    }
+    /** @type {Set<string>} */
+    const seen = new Set();
+    for (const list of SEARCH_LISTS) {
+      const items = /** @type {IssueLite[]} */ (
+        issue_stores.snapshotFor(list.client_id) || []
+      );
+      for (const it of items) {
+        const parent = String(it.parent || '');
+        const id = String(it.id || '');
+        if (!parent || seen.has(id)) {
+          continue;
+        }
+        seen.add(id);
+        const bucket = by_parent.get(parent);
+        if (bucket) {
+          bucket.push(it);
+        } else {
+          by_parent.set(parent, [it]);
+        }
+      }
+    }
+    for (const bucket of by_parent.values()) {
+      bucket.sort(cmpPriorityThenCreated);
+    }
+    return by_parent;
+  }
+
+  /**
+   * Whether an id or title contains the needle.
+   *
+   * @param {{ id?: string, title?: string }} item
+   * @param {string} needle
+   */
+  function matchesNeedle(item, needle) {
+    const id = String(item.id || '').toLowerCase();
+    const title = String(item.title || '').toLowerCase();
+    return id.includes(needle) || title.includes(needle);
+  }
+
+  /**
+   * Epic groups to render. Without a search term every group renders its own
+   * children on expand. With one, a group is kept when the epic matches (all
+   * children shown) or when its children match (only those shown).
+   *
+   * @returns {{ group: any, children: IssueLite[] | null }[]}
+   */
+  function visibleEntries() {
+    if (!search_text) {
+      return groups.map((g) => ({ group: g, children: null }));
+    }
+    const needle = search_text.toLowerCase();
+    const by_parent = childrenByParent();
+    /** @type {{ group: any, children: IssueLite[] | null }[]} */
+    const entries = [];
+    for (const g of groups) {
+      const epic = g.epic || {};
+      const children = by_parent.get(String(epic.id || '')) || [];
+      if (matchesNeedle(epic, needle)) {
+        entries.push({ group: g, children });
+        continue;
+      }
+      const hits = children.filter((it) => matchesNeedle(it, needle));
+      if (hits.length > 0) {
+        entries.push({ group: g, children: hits });
+      }
+    }
+    return entries;
+  }
+
+  /**
+   * Groups matching the current search term.
+   */
+  function visibleGroups() {
+    return visibleEntries().map((entry) => entry.group);
+  }
+
+  /**
+   * Message shown when nothing is rendered.
+   */
+  function emptyMessage() {
+    if (groups.length === 0) {
+      return 'No epics found.';
+    }
+    if (search_loading) {
+      return 'Searching…';
+    }
+    return 'No matching epics or issues.';
+  }
+
+  function template() {
+    const visible = visibleEntries();
+    return html`
+      <div class="panel__header">
+        <input
+          type="search"
+          placeholder="Search…"
+          aria-label="Search epics and issues"
+          @input=${onSearchInput}
+          .value=${search_text}
+        />
+      </div>
+      <div class="panel__body" id="epics-list">
+        ${visible.length === 0
+          ? html`<div class="muted" style="padding:10px 12px;">
+              ${emptyMessage()}
+            </div>`
+          : visible.map((entry) => groupTemplate(entry.group, entry.children))}
+      </div>
+    `;
   }
 
   /**
    * @param {any} g
+   * @param {IssueLite[] | null} [search_children] - Rows to show while
+   *   searching; `null` renders the epic's own children on expand.
    */
-  function groupTemplate(g) {
+  function groupTemplate(g, search_children = null) {
     const epic = g.epic || {};
     const id = String(epic.id || '');
-    const is_open = expanded.has(id);
+    // Search hits are always shown, expanded or not
+    const is_open = search_children !== null || expanded.has(id);
     // Compose children via selectors
-    const list = selectors ? selectors.selectEpicChildren(id) : [];
-    const is_loading = loading.has(id);
+    const list =
+      search_children !== null
+        ? search_children
+        : selectors
+          ? selectors.selectEpicChildren(id)
+          : [];
+    const is_loading = search_children === null && loading.has(id);
     return html`
       <div class="epic-group" data-epic-id=${id}>
         <div
@@ -117,22 +350,10 @@ export function createEpicsView(
                 : list.length === 0
                   ? html`<div class="muted">No issues found</div>`
                   : html`<table class="table">
-                      <colgroup>
-                        <col style="width: 100px" />
-                        <col style="width: 120px" />
-                        <col />
-                        <col style="width: 120px" />
-                        <col style="width: 160px" />
-                        <col style="width: 130px" />
-                      </colgroup>
+                      ${column_resizer.colgroup()}
                       <thead>
                         <tr>
-                          <th>ID</th>
-                          <th>Type</th>
-                          <th>Title</th>
-                          <th>Status</th>
-                          <th>Assignee</th>
-                          <th>Priority</th>
+                          ${column_resizer.headerCells()}
                         </tr>
                       </thead>
                       <tbody>
@@ -260,22 +481,32 @@ export function createEpicsView(
     return next_groups;
   }
 
+  /** Expand the first epic on screen. Search hits are shown regardless. */
+  async function expandFirst() {
+    if (search_text) {
+      return;
+    }
+    try {
+      const visible = visibleGroups();
+      if (visible.length === 0) {
+        return;
+      }
+      const first_id = String(visible[0].epic?.id || '');
+      if (first_id && !expanded.has(first_id)) {
+        // This will render and load children lazily
+        await toggle(first_id);
+      }
+    } catch {
+      // ignore auto-expand failures
+    }
+  }
+
   return {
     async load() {
       groups = buildGroupsFromSnapshot();
       doRender();
-      // Auto-expand first epic on screen
-      try {
-        if (groups.length > 0) {
-          const first_id = String(groups[0].epic?.id || '');
-          if (first_id && !expanded.has(first_id)) {
-            // This will render and load children lazily
-            await toggle(first_id);
-          }
-        }
-      } catch {
-        // ignore auto-expand failures
-      }
+      await syncSearchSubscriptions();
+      await expandFirst();
     }
   };
 }

--- a/app/views/epics.test.js
+++ b/app/views/epics.test.js
@@ -1,9 +1,122 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { createSubscriptionIssueStore } from '../data/subscription-issue-store.js';
 import { createSubscriptionStore } from '../data/subscriptions-store.js';
 import { createEpicsView } from './epics.js';
 
+/**
+ * Mount an epics view with the given epics seeded in `tab:epics`.
+ *
+ * @param {any[]} epics
+ */
+function createEpicsHarness(epics) {
+  document.body.innerHTML = '<div id="m"></div>';
+  const mount = /** @type {HTMLElement} */ (document.getElementById('m'));
+  /** @type {Map<string, any>} */
+  const stores = new Map();
+  /** @type {Set<() => void>} */
+  const listeners = new Set();
+  /** @param {string} id */
+  const getStore = (id) => {
+    let s = stores.get(id);
+    if (!s) {
+      s = createSubscriptionIssueStore(id);
+      stores.set(id, s);
+      s.subscribe(() => {
+        for (const fn of Array.from(listeners)) {
+          try {
+            fn();
+          } catch {
+            /* ignore */
+          }
+        }
+      });
+    }
+    return s;
+  };
+  const issue_stores = {
+    getStore,
+    /** @param {string} id */
+    snapshotFor(id) {
+      return getStore(id).snapshot().slice();
+    },
+    /** @param {() => void} fn */
+    subscribe(fn) {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    }
+  };
+  issue_stores.getStore('tab:epics').applyPush({
+    type: 'snapshot',
+    id: 'tab:epics',
+    revision: 1,
+    issues: epics
+  });
+  const view = createEpicsView(
+    mount,
+    /** @type {any} */ ({ updateIssue: vi.fn() }),
+    () => {},
+    createSubscriptionStore(async () => {}),
+    /** @type {any} */ (issue_stores)
+  );
+  /**
+   * Seed the issue list backing child search.
+   *
+   * @param {any[]} issues
+   * @param {string} [client_id]
+   */
+  function seedSearchList(issues, client_id = 'epics:search-open') {
+    issue_stores.getStore(client_id).applyPush({
+      type: 'snapshot',
+      id: client_id,
+      revision: 1,
+      issues
+    });
+  }
+  return { mount, view, seedSearchList };
+}
+
+/**
+ * Type into the epics search input and let the search lists subscribe.
+ *
+ * @param {HTMLElement} mount
+ * @param {string} text
+ */
+async function typeSearch(mount, text) {
+  const input = /** @type {HTMLInputElement} */ (
+    mount.querySelector('input[type="search"]')
+  );
+  input.value = text;
+  input.dispatchEvent(new Event('input'));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Titles of the issue rows currently rendered.
+ *
+ * @param {HTMLElement} mount
+ */
+function visibleRowTitles(mount) {
+  return Array.from(mount.querySelectorAll('tr.epic-row')).map((row) =>
+    (row.querySelectorAll('td')[2].textContent || '').trim()
+  );
+}
+
+/**
+ * Ids of the epic groups currently rendered.
+ *
+ * @param {HTMLElement} mount
+ */
+function visibleEpicIds(mount) {
+  return Array.from(mount.querySelectorAll('.epic-group')).map(
+    (el) => el.getAttribute('data-epic-id') || ''
+  );
+}
+
 describe('views/epics', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem('beads-ui.epics.search');
+  });
+
   test('loads groups from store and expands to show non-closed children, navigates on click', async () => {
     document.body.innerHTML = '<div id="m"></div>';
     const mount = /** @type {HTMLElement} */ (document.getElementById('m'));
@@ -526,5 +639,311 @@ describe('views/epics', () => {
       mount.querySelector('tr.epic-row td:nth-child(3) input[type="text"]')
     );
     expect(input).not.toBeNull();
+  });
+
+  test('renders resizable column headers and persists a drag', async () => {
+    window.localStorage.removeItem('beads-ui.columns.epics');
+    document.body.innerHTML = '<div id="m"></div>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('m'));
+    const data = {
+      updateIssue: vi.fn(),
+      getIssue: vi.fn(async (id) => ({ id }))
+    };
+    const stores6 = new Map();
+    const listeners6 = new Set();
+    /** @param {string} id */
+    const getStore6 = (id) => {
+      let s = stores6.get(id);
+      if (!s) {
+        s = createSubscriptionIssueStore(id);
+        stores6.set(id, s);
+        s.subscribe(() => {
+          for (const fn of Array.from(listeners6)) {
+            try {
+              fn();
+            } catch {
+              /* ignore */
+            }
+          }
+        });
+      }
+      return s;
+    };
+    const issueStores6 = {
+      getStore: getStore6,
+      /** @param {string} id */
+      snapshotFor(id) {
+        return getStore6(id).snapshot().slice();
+      },
+      /** @param {() => void} fn */
+      subscribe(fn) {
+        listeners6.add(fn);
+        return () => listeners6.delete(fn);
+      }
+    };
+    const subscriptions3 = createSubscriptionStore(async () => {});
+    issueStores6.getStore('tab:epics').applyPush({
+      type: 'snapshot',
+      id: 'tab:epics',
+      revision: 1,
+      issues: [
+        {
+          id: 'UI-40',
+          title: 'Epic Columns',
+          issue_type: 'epic',
+          dependents: [{ id: 'UI-41' }]
+        }
+      ]
+    });
+    const view = createEpicsView(
+      mount,
+      /** @type {any} */ (data),
+      () => {},
+      subscriptions3,
+      /** @type {any} */ (issueStores6)
+    );
+    await view.load();
+    issueStores6.getStore('detail:UI-40').applyPush({
+      type: 'snapshot',
+      id: 'detail:UI-40',
+      revision: 1,
+      issues: [
+        {
+          id: 'UI-40',
+          title: 'Epic Columns',
+          issue_type: 'epic',
+          dependents: [
+            {
+              id: 'UI-41',
+              title: 'Child',
+              status: 'open',
+              priority: 2,
+              issue_type: 'task'
+            }
+          ]
+        }
+      ]
+    });
+    await view.load();
+
+    const handles = mount.querySelectorAll('.epic-children th .col-resizer');
+    handles[0].dispatchEvent(
+      new MouseEvent('pointerdown', { clientX: 300, bubbles: true })
+    );
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 270 }));
+    window.dispatchEvent(new MouseEvent('pointerup', {}));
+
+    expect(handles.length).toBe(7);
+    const first_col = /** @type {HTMLElement} */ (
+      mount.querySelector('.epic-children colgroup > col')
+    );
+    expect(first_col.style.width).toBe('70px');
+    const stored = JSON.parse(
+      window.localStorage.getItem('beads-ui.columns.epics') || '[]'
+    );
+    expect(stored[0]).toBe(70);
+    window.localStorage.removeItem('beads-ui.columns.epics');
+  });
+
+  test('renders a search input in the header', async () => {
+    const { mount, view } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' }
+    ]);
+
+    await view.load();
+
+    const input = /** @type {HTMLInputElement|null} */ (
+      mount.querySelector('.panel__header input[type="search"]')
+    );
+    expect(input).not.toBeNull();
+    expect(input?.placeholder).toBe('Search…');
+  });
+
+  test('filters epics by title', async () => {
+    const { mount, view } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' },
+      { id: 'UI-51', title: 'Keyboard navigation', issue_type: 'epic' }
+    ]);
+    await view.load();
+
+    await typeSearch(mount, 'keyboard');
+
+    expect(visibleEpicIds(mount)).toEqual(['UI-51']);
+  });
+
+  test('filters epics by id', async () => {
+    const { mount, view } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' },
+      { id: 'UI-51', title: 'Keyboard navigation', issue_type: 'epic' }
+    ]);
+    await view.load();
+
+    await typeSearch(mount, 'ui-50');
+
+    expect(visibleEpicIds(mount)).toEqual(['UI-50']);
+  });
+
+  test('keeps the search input while filtering', async () => {
+    const { mount, view } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' }
+    ]);
+    await view.load();
+
+    await typeSearch(mount, 'table');
+
+    const input = /** @type {HTMLInputElement} */ (
+      mount.querySelector('input[type="search"]')
+    );
+    expect(input.value).toBe('table');
+  });
+
+  test('matches child issues by title', async () => {
+    const { mount, view, seedSearchList } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' },
+      { id: 'UI-51', title: 'Keyboard navigation', issue_type: 'epic' }
+    ]);
+    await view.load();
+    seedSearchList([
+      { id: 'UI-60', title: 'Resize columns', status: 'open', parent: 'UI-50' },
+      { id: 'UI-61', title: 'Arrow keys', status: 'open', parent: 'UI-51' }
+    ]);
+
+    await typeSearch(mount, 'arrow');
+
+    expect(visibleEpicIds(mount)).toEqual(['UI-51']);
+    expect(visibleRowTitles(mount)).toEqual(['Arrow keys']);
+  });
+
+  test('matches child issues by id', async () => {
+    const { mount, view, seedSearchList } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' }
+    ]);
+    await view.load();
+    seedSearchList([
+      { id: 'UI-60', title: 'Resize columns', status: 'open', parent: 'UI-50' }
+    ]);
+
+    await typeSearch(mount, 'ui-60');
+
+    expect(visibleEpicIds(mount)).toEqual(['UI-50']);
+    expect(visibleRowTitles(mount)).toEqual(['Resize columns']);
+  });
+
+  test('matches closed child issues', async () => {
+    const { mount, view, seedSearchList } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' }
+    ]);
+    await view.load();
+    seedSearchList(
+      [
+        {
+          id: 'UI-62',
+          title: 'Old spike',
+          status: 'closed',
+          parent: 'UI-50'
+        }
+      ],
+      'epics:search-closed'
+    );
+
+    await typeSearch(mount, 'spike');
+
+    expect(visibleEpicIds(mount)).toEqual(['UI-50']);
+    expect(visibleRowTitles(mount)).toEqual(['Old spike']);
+  });
+
+  test('shows only the matching children of an epic', async () => {
+    const { mount, view, seedSearchList } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' }
+    ]);
+    await view.load();
+    seedSearchList([
+      { id: 'UI-60', title: 'Resize columns', status: 'open', parent: 'UI-50' },
+      { id: 'UI-63', title: 'Sort columns', status: 'open', parent: 'UI-50' }
+    ]);
+
+    await typeSearch(mount, 'resize');
+
+    expect(visibleRowTitles(mount)).toEqual(['Resize columns']);
+  });
+
+  test('shows all children when the epic itself matches', async () => {
+    const { mount, view, seedSearchList } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' }
+    ]);
+    await view.load();
+    seedSearchList([
+      { id: 'UI-60', title: 'Resize columns', status: 'open', parent: 'UI-50' },
+      { id: 'UI-63', title: 'Sort columns', status: 'open', parent: 'UI-50' }
+    ]);
+
+    await typeSearch(mount, 'ergonomics');
+
+    expect(visibleRowTitles(mount)).toEqual(['Resize columns', 'Sort columns']);
+  });
+
+  test('reports when nothing matches the search', async () => {
+    const { mount, view, seedSearchList } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' }
+    ]);
+    await view.load();
+    seedSearchList([
+      { id: 'UI-60', title: 'Resize columns', status: 'open', parent: 'UI-50' }
+    ]);
+
+    await typeSearch(mount, 'nothing here');
+
+    expect(visibleEpicIds(mount)).toEqual([]);
+    expect(mount.textContent).toContain('No matching epics or issues.');
+  });
+
+  test('reports an empty epics list without a search', async () => {
+    const { mount, view } = createEpicsHarness([]);
+
+    await view.load();
+
+    expect(mount.textContent).toContain('No epics found.');
+  });
+
+  test('persists the search term', async () => {
+    const { mount, view } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' }
+    ]);
+    await view.load();
+
+    await typeSearch(mount, 'table');
+
+    expect(window.localStorage.getItem('beads-ui.epics.search')).toBe('table');
+  });
+
+  test('restores the persisted search term', async () => {
+    window.localStorage.setItem('beads-ui.epics.search', 'keyboard');
+
+    const { mount, view } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' },
+      { id: 'UI-51', title: 'Keyboard navigation', issue_type: 'epic' }
+    ]);
+    await view.load();
+
+    const input = /** @type {HTMLInputElement} */ (
+      mount.querySelector('input[type="search"]')
+    );
+    expect(input.value).toBe('keyboard');
+    expect(visibleEpicIds(mount)).toEqual(['UI-51']);
+  });
+
+  test('expands the first matching epic', async () => {
+    window.localStorage.setItem('beads-ui.epics.search', 'keyboard');
+    const { mount, view } = createEpicsHarness([
+      { id: 'UI-50', title: 'Table ergonomics', issue_type: 'epic' },
+      { id: 'UI-51', title: 'Keyboard navigation', issue_type: 'epic' }
+    ]);
+
+    await view.load();
+
+    const header = /** @type {HTMLElement} */ (
+      mount.querySelector('.epic-group[data-epic-id="UI-51"] .epic-header')
+    );
+    expect(header.getAttribute('aria-expanded')).toBe('true');
   });
 });

--- a/app/views/issue-row.js
+++ b/app/views/issue-row.js
@@ -4,10 +4,31 @@ import { emojiForPriority } from '../utils/priority-badge.js';
 import { priority_levels } from '../utils/priority.js';
 import { statusLabel } from '../utils/status.js';
 import { createTypeBadge } from '../utils/type-badge.js';
+import { columnSpacerCell } from './column-resize.js';
+
+/**
+ * @import { ColumnSpec } from './column-resize.js'
+ */
 
 /**
  * @typedef {{ id: string, title?: string, status?: string, priority?: number, issue_type?: string, assignee?: string, dependency_count?: number, dependent_count?: number }} IssueRowData
  */
+
+/**
+ * Columns rendered by `createIssueRowRenderer`, in cell order. Used by the
+ * list and epics views to render matching, resizable headers.
+ *
+ * @type {ColumnSpec[]}
+ */
+export const ISSUE_ROW_COLUMNS = [
+  { key: 'id', label: 'ID', width: 100 },
+  { key: 'type', label: 'Type', width: 120 },
+  { key: 'title', label: 'Title', width: 320, flex: true },
+  { key: 'status', label: 'Status', width: 120 },
+  { key: 'assignee', label: 'Assignee', width: 160 },
+  { key: 'priority', label: 'Priority', width: 130 },
+  { key: 'deps', label: 'Deps', width: 80 }
+];
 
 /**
  * Create a reusable issue row renderer used by list and epics views.
@@ -209,6 +230,7 @@ export function createIssueRowRenderer(options) {
             >`
           : ''}
       </td>
+      ${columnSpacerCell()}
     </tr>`;
   }
 

--- a/app/views/list.js
+++ b/app/views/list.js
@@ -5,7 +5,8 @@ import { ISSUE_TYPES, typeLabel } from '../utils/issue-type.js';
 import { issueHashFor } from '../utils/issue-url.js';
 import { debug } from '../utils/logging.js';
 import { statusLabel } from '../utils/status.js';
-import { createIssueRowRenderer } from './issue-row.js';
+import { createColumnResizer } from './column-resize.js';
+import { ISSUE_ROW_COLUMNS, createIssueRowRenderer } from './issue-row.js';
 
 // List view implementation; requires a transport send function.
 
@@ -97,6 +98,14 @@ export function createListView(
     requestRender: doRender,
     getSelectedId: () => selected_id,
     row_class: 'issue-row'
+  });
+
+  // Resizable columns, persisted per view
+  const column_resizer = createColumnResizer({
+    mount_element,
+    storage_key: 'beads-ui.columns.issues',
+    columns: ISSUE_ROW_COLUMNS,
+    requestRender: doRender
   });
 
   /**
@@ -292,26 +301,12 @@ export function createListView(
                 class="table"
                 role="grid"
                 aria-rowcount=${String(filtered.length)}
-                aria-colcount="6"
+                aria-colcount=${String(ISSUE_ROW_COLUMNS.length)}
               >
-                <colgroup>
-                  <col style="width: 100px" />
-                  <col style="width: 120px" />
-                  <col />
-                  <col style="width: 120px" />
-                  <col style="width: 160px" />
-                  <col style="width: 130px" />
-                  <col style="width: 80px" />
-                </colgroup>
+                ${column_resizer.colgroup()}
                 <thead>
                   <tr role="row">
-                    <th role="columnheader">ID</th>
-                    <th role="columnheader">Type</th>
-                    <th role="columnheader">Title</th>
-                    <th role="columnheader">Status</th>
-                    <th role="columnheader">Assignee</th>
-                    <th role="columnheader">Priority</th>
-                    <th role="columnheader">Deps</th>
+                    ${column_resizer.headerCells()}
                   </tr>
                 </thead>
                 <tbody role="rowgroup">
@@ -575,6 +570,7 @@ export function createListView(
   return {
     load,
     destroy() {
+      column_resizer.destroy();
       mount_element.replaceChildren();
       document.removeEventListener('click', clickOutsideHandler);
       if (unsubscribe) {

--- a/app/views/list.test.js
+++ b/app/views/list.test.js
@@ -90,6 +90,46 @@ function createTestIssueStores() {
 }
 
 describe('views/list', () => {
+  test('renders resizable column headers and persists a drag', async () => {
+    window.localStorage.removeItem('beads-ui.columns.issues');
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issueStores = createTestIssueStores();
+    issueStores.getStore('tab:issues').applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: [{ id: 'UI-1', title: 'One', status: 'open', priority: 1 }]
+    });
+    const view = createListView(
+      mount,
+      async () => [],
+      undefined,
+      undefined,
+      undefined,
+      issueStores
+    );
+    await view.load();
+
+    const handles = mount.querySelectorAll('#list-root th .col-resizer');
+    handles[0].dispatchEvent(
+      new MouseEvent('pointerdown', { clientX: 300, bubbles: true })
+    );
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 340 }));
+    window.dispatchEvent(new MouseEvent('pointerup', {}));
+
+    expect(handles.length).toBe(7);
+    const first_col = /** @type {HTMLElement} */ (
+      mount.querySelector('#list-root colgroup > col')
+    );
+    expect(first_col.style.width).toBe('140px');
+    const stored = JSON.parse(
+      window.localStorage.getItem('beads-ui.columns.issues') || '[]'
+    );
+    expect(stored[0]).toBe(140);
+    window.localStorage.removeItem('beads-ui.columns.issues');
+  });
+
   test('renders issues from push stores and navigates on row click', async () => {
     document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
     const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));


### PR DESCRIPTION
## Resizable columns (`/issues` and `/epics`)

New shared module `app/views/column-resize.js`:

- Drag handles on every header cell, plus keyboard resize (focus a handle, ←/→ in 16px steps) and double-click to reset.
- Widths persist per view under `beads-ui.columns.issues` / `beads-ui.columns.epics`, clamped to 48–1000px, with defaults restored for stale or invalid data.
- The Title column stays auto-sized until you drag it; a trailing spacer column then absorbs the remaining width so the table still fills the panel. Beyond that the table scrolls horizontally inside its block.
- On `/epics`, every per-epic table shares one set of widths and updates together while dragging.

Two related fixes needed to line the columns up:

- `epics.js` declared 6 columns while the shared row renderer always emitted 7 cells, leaving a headerless Deps column. Both views now render the same 7 columns from `ISSUE_ROW_COLUMNS`.
- `list.js` advertised `aria-colcount="6"` for 7 columns.

Cell content now clips at the column edge (with an ellipsis on the issue ID) instead of spilling into the neighbouring column when a column is narrowed.

## Search on `/epics`

`/epics` gets the same header and search input as `/issues`, persisted under `beads-ui.epics.search`.

Matching covers epics **and** their child issues:

- Epic id/title matches → the group is kept and shows all its children.
- Only children match → the group is kept and shows just the matching rows, expanded in place even if it was collapsed.
- Nothing matches → "No matching epics or issues." (with a brief "Searching…" while the first snapshot is in flight).

Child matching uses the `parent` field already returned by `bd list --json`. The `all-issues` and `closed-issues` lists are subscribed only while a search term is active and released when it is cleared, so the steady-state cost of the epics tab is unchanged and closed children are still findable. Matching is on id and title only, same as the `/issues` search.

## Testing

- `npm run all` (lint, tsc, 319 tests, prettier) passes.
- New unit tests: `app/views/column-resize.test.js` (20), plus resize and search tests in `list.test.js` / `epics.test.js`.
- Verified in a browser against a live `bd` workspace: dragging, keyboard resize, persistence across reload, horizontal overflow, per-epic table sync, and searching for open and closed child issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrsFaf9PhMu694RGZ79rGP
