### PR TITLE
Auto-size the ID column so long issue ids are not cut off

### DIFF
--- a/app/styles.css
+++ b/app/styles.css
@@ -1319,7 +1319,15 @@ input.inline-edit:focus {
 .table {
   width: 100%;
   border-collapse: collapse;
-  table-layout: fixed; /* keep column proportions stable while editing */
+  /* Auto layout lets the ID column grow to fit long, prefixed issue ids
+     (e.g. "my-project-name-abc-1"). All other columns keep explicit <col>
+     widths so proportions stay stable while editing; only Title flexes. */
+  table-layout: auto;
+
+  th:first-child,
+  td:first-child {
+    white-space: nowrap;
+  }
 
   th,
   td {

--- a/app/views/epics.js
+++ b/app/views/epics.js
@@ -118,7 +118,7 @@ export function createEpicsView(
                   ? html`<div class="muted">No issues found</div>`
                   : html`<table class="table">
                       <colgroup>
-                        <col style="width: 100px" />
+                        <col />
                         <col style="width: 120px" />
                         <col />
                         <col style="width: 120px" />

--- a/app/views/list.js
+++ b/app/views/list.js
@@ -368,7 +368,7 @@ export function createListView(
                 aria-colcount="6"
               >
                 <colgroup>
-                  <col style="width: 100px" />
+                  <col />
                   <col style="width: 120px" />
                   <col />
                   <col style="width: 120px" />


### PR DESCRIPTION
## Problem

Bead ids with long workspace prefixes (e.g. `shopfloor-internal-agent-sus-1`, ~30 chars) overflow the fixed 100px ID column in the Issues and Epics tables. Because the tables use `table-layout: fixed`, the overflowing text paints over the Type column:

Before: the ID text renders underneath/over the Type badges, making both unreadable.

## Fix

- Switch `.table` to `table-layout: auto` and drop the fixed `width: 100px` from the ID `<col>` in both `list.js` and `epics.js`.
- Keep ID cells on a single line (`white-space: nowrap` on the first column) so the column sizes to the longest id.
- All other columns keep their explicit `<col>` widths, so proportions stay stable while inline-editing; only the Title column flexes.

## Testing

- `app/views/list.test.js`, `app/views/epics.test.js`, `app/views/list.inline-edits.test.js` pass.
- Verified locally against a workspace with 30+ char ids: full ids visible, no overlap, titles truncate instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)