### PR TITLE
Set shell option based on platform

### DIFF
--- a/server/bd.js
+++ b/server/bd.js
@@ -89,7 +89,7 @@ function runBdUnlocked(args, options = {}) {
   const spawn_opts = {
     cwd: options.cwd || process.cwd(),
     env: env_with_db,
-    shell: false,
+    shell: process.platform === 'win32',
     windowsHide: true
   };
 


### PR DESCRIPTION
## Problem

On Windows, `bdui` fails with `spawn EINVAL` when `BD_BIN` is set to a `.cmd` file (e.g. the pnpm-installed `bd.cmd` shim). This is because `server/bd.js` spawns the binary with `shell: false`, and Windows cannot execute `.cmd` files without a shell.

## Fix

In `server/bd.js`, change the `spawn_opts` object:

```js
// before
shell: false,

// after
shell: process.platform === 'win32',
```

This allows `.cmd` and `.ps1` shims to be invoked correctly on Windows while keeping `shell: false` on Unix where it's the right default.

## Workaround

Download the native `bd.exe` from the beads GitHub releases and set `BD_BIN=C:\path\to\bd.exe` — but this diverges from the npm-installed version and requires manual updates.

## Environment

- OS: Windows 11
- Node: v26.5.1
- beads-ui: 0.12.5
- bd: 1.1.2 (pnpm install)