### PR TITLE
fix(detail): render delete prompt safely

### DIFF
--- a/app/views/detail.js
+++ b/app/views/detail.js
@@ -159,59 +159,91 @@ export function createDetailView(
 
   /** @type {HTMLDialogElement | null} */
   let delete_dialog = null;
+  /** @type {string | null} */
+  let delete_target_id = null;
+
+  function closeDeleteDialog() {
+    if (!delete_dialog) {
+      return;
+    }
+    if (typeof delete_dialog.close === 'function') {
+      delete_dialog.close();
+    }
+    delete_dialog.removeAttribute('open');
+  }
+
+  /**
+   * @param {Event} ev
+   */
+  function onDeleteDialogCancel(ev) {
+    ev.preventDefault();
+    closeDeleteDialog();
+  }
+
+  async function onDeleteConfirm() {
+    const id = delete_target_id;
+    closeDeleteDialog();
+    if (id) {
+      await performDelete(id);
+    }
+  }
 
   function ensureDeleteDialog() {
-    if (delete_dialog) return delete_dialog;
+    if (delete_dialog) {
+      return delete_dialog;
+    }
     delete_dialog = document.createElement('dialog');
     delete_dialog.id = 'delete-confirm-dialog';
     delete_dialog.setAttribute('role', 'alertdialog');
     delete_dialog.setAttribute('aria-modal', 'true');
+    delete_dialog.setAttribute('aria-labelledby', 'delete-confirm-title');
+    delete_dialog.setAttribute('aria-describedby', 'delete-confirm-message');
+    delete_dialog.addEventListener('cancel', onDeleteDialogCancel);
     document.body.appendChild(delete_dialog);
     return delete_dialog;
   }
 
   function openDeleteDialog() {
-    if (!current) return;
+    if (!current) {
+      return;
+    }
     const dialog = ensureDeleteDialog();
-    const issueId = current.id;
-    const issueTitle = current.title || '(no title)';
-    dialog.innerHTML = `
-      <div class="delete-confirm">
-        <h2 class="delete-confirm__title">Delete Issue</h2>
-        <p class="delete-confirm__message">
-          Are you sure you want to delete issue <strong>${issueId}</strong> — <strong>${issueTitle}</strong>? This action cannot be undone.
-        </p>
-        <div class="delete-confirm__actions">
-          <button type="button" class="btn" id="delete-cancel-btn">Cancel</button>
-          <button type="button" class="btn danger" id="delete-confirm-btn">Delete</button>
+    const issue_id = current.id;
+    const issue_title = current.title || '(no title)';
+    delete_target_id = issue_id;
+    render(
+      html`
+        <div class="delete-confirm">
+          <h2 class="delete-confirm__title" id="delete-confirm-title">
+            Delete Issue
+          </h2>
+          <p class="delete-confirm__message" id="delete-confirm-message">
+            Are you sure you want to delete issue
+            <strong>${issue_id}</strong> — <strong>${issue_title}</strong>? This
+            action cannot be undone.
+          </p>
+          <div class="delete-confirm__actions">
+            <button
+              type="button"
+              class="btn"
+              id="delete-cancel-btn"
+              @click=${closeDeleteDialog}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="btn danger"
+              id="delete-confirm-btn"
+              @click=${onDeleteConfirm}
+            >
+              Delete
+            </button>
+          </div>
         </div>
-      </div>
-    `;
-    const cancelBtn = dialog.querySelector('#delete-cancel-btn');
-    const confirmBtn = dialog.querySelector('#delete-confirm-btn');
-
-    cancelBtn?.addEventListener('click', () => {
-      if (typeof dialog.close === 'function') {
-        dialog.close();
-      }
-      dialog.removeAttribute('open');
-    });
-
-    confirmBtn?.addEventListener('click', async () => {
-      if (typeof dialog.close === 'function') {
-        dialog.close();
-      }
-      dialog.removeAttribute('open');
-      await performDelete();
-    });
-
-    dialog.addEventListener('cancel', (ev) => {
-      ev.preventDefault();
-      if (typeof dialog.close === 'function') {
-        dialog.close();
-      }
-      dialog.removeAttribute('open');
-    });
+      `,
+      dialog
+    );
 
     if (typeof dialog.showModal === 'function') {
       try {
@@ -223,19 +255,26 @@ export function createDetailView(
     } else {
       dialog.setAttribute('open', '');
     }
+    const cancel_button = /** @type {HTMLButtonElement | null} */ (
+      dialog.querySelector('#delete-cancel-btn')
+    );
+    cancel_button?.focus();
   }
 
-  async function performDelete() {
-    if (!current) return;
-    const id = current.id;
+  /**
+   * @param {string} id
+   */
+  async function performDelete(id) {
     try {
       await sendFn('delete-issue', { id });
-      current = null;
-      current_id = null;
-      doRender();
-      // Navigate back to close the dialog
-      const view = parseView(window.location.hash || '');
-      navigateFn(`#/${view}`);
+      if (current?.id === id) {
+        current = null;
+        current_id = null;
+        doRender();
+        // Navigate back to close the dialog
+        const view = parseView(window.location.hash || '');
+        navigateFn(`#/${view}`);
+      }
     } catch (err) {
       log('delete failed: %o', err);
       showToast('Failed to delete issue', 'error');
@@ -1689,8 +1728,10 @@ export function createDetailView(
     destroy() {
       mount_element.replaceChildren();
       if (delete_dialog && delete_dialog.parentNode) {
+        delete_dialog.removeEventListener('cancel', onDeleteDialogCancel);
         delete_dialog.parentNode.removeChild(delete_dialog);
         delete_dialog = null;
+        delete_target_id = null;
       }
     }
   };

--- a/app/views/detail.test.js
+++ b/app/views/detail.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { createDetailView } from './detail.js';
 
 describe('views/detail', () => {
@@ -546,10 +546,93 @@ describe('views/detail', () => {
 
       // Should show issue ID and title
       const message = dialog?.querySelector('.delete-confirm__message');
-      expect(message?.innerHTML).toContain('<strong>UI-100</strong>');
-      expect(message?.innerHTML).toContain(
-        '<strong>Confirm delete test</strong>'
+      const emphasized = Array.from(
+        message?.querySelectorAll('strong') || []
+      ).map((element) => element.textContent);
+      expect(emphasized).toEqual(['UI-100', 'Confirm delete test']);
+      expect(dialog?.getAttribute('aria-labelledby')).toBe(
+        'delete-confirm-title'
       );
+      expect(dialog?.getAttribute('aria-describedby')).toBe(
+        'delete-confirm-message'
+      );
+      expect(document.activeElement?.id).toBe('delete-cancel-btn');
+    });
+
+    test('renders malicious issue titles as inert text', async () => {
+      document.body.innerHTML =
+        '<section class="panel"><div id="mount"></div></section>';
+      const mount = /** @type {HTMLElement} */ (
+        document.getElementById('mount')
+      );
+      const malicious_title = '<img src=x onerror="alert(1)">';
+      const issue = {
+        id: 'UI-100-XSS',
+        title: malicious_title,
+        dependencies: [],
+        dependents: []
+      };
+      const stores = {
+        /** @param {string} id */
+        snapshotFor(id) {
+          return id === 'detail:UI-100-XSS' ? [issue] : [];
+        },
+        subscribe() {
+          return () => {};
+        }
+      };
+      const view = createDetailView(mount, async () => ({}), undefined, stores);
+      await view.load('UI-100-XSS');
+
+      /** @type {HTMLButtonElement} */ (
+        mount.querySelector('.delete-issue-btn')
+      ).click();
+
+      const dialog = /** @type {HTMLDialogElement} */ (
+        document.getElementById('delete-confirm-dialog')
+      );
+      expect(dialog.querySelector('.delete-confirm__message img')).toBeNull();
+      expect(dialog.textContent).toContain(malicious_title);
+    });
+
+    test('binds the native cancel handler once across repeated opens', async () => {
+      document.body.innerHTML =
+        '<section class="panel"><div id="mount"></div></section>';
+      const mount = /** @type {HTMLElement} */ (
+        document.getElementById('mount')
+      );
+      const issue = {
+        id: 'UI-100-CANCEL',
+        title: 'Repeated cancel',
+        dependencies: [],
+        dependents: []
+      };
+      const stores = {
+        /** @param {string} id */
+        snapshotFor(id) {
+          return id === 'detail:UI-100-CANCEL' ? [issue] : [];
+        },
+        subscribe() {
+          return () => {};
+        }
+      };
+      const view = createDetailView(mount, async () => ({}), undefined, stores);
+      await view.load('UI-100-CANCEL');
+      const delete_button = /** @type {HTMLButtonElement} */ (
+        mount.querySelector('.delete-issue-btn')
+      );
+      delete_button.click();
+      const dialog = /** @type {HTMLDialogElement} */ (
+        document.getElementById('delete-confirm-dialog')
+      );
+      const close = vi.fn(() => dialog.removeAttribute('open'));
+      dialog.close = close;
+
+      dialog.dispatchEvent(new Event('cancel', { cancelable: true }));
+      delete_button.click();
+      dialog.dispatchEvent(new Event('cancel', { cancelable: true }));
+
+      expect(close).toHaveBeenCalledTimes(2);
     });
 
     test('cancel button closes dialog without deleting', async () => {
@@ -660,6 +743,74 @@ describe('views/detail', () => {
       // View should be cleared (showing placeholder)
       const placeholder = mount.querySelector('.muted');
       expect(placeholder?.textContent).toContain('No issue selected');
+    });
+
+    test('deletes the issue shown when confirmation opened', async () => {
+      document.body.innerHTML =
+        '<section class="panel"><div id="mount"></div></section>';
+      const mount = /** @type {HTMLElement} */ (
+        document.getElementById('mount')
+      );
+      const issues = new Map([
+        [
+          'UI-OLD',
+          {
+            id: 'UI-OLD',
+            title: 'Original issue',
+            dependencies: [],
+            dependents: []
+          }
+        ],
+        [
+          'UI-NEW',
+          {
+            id: 'UI-NEW',
+            title: 'New issue',
+            dependencies: [],
+            dependents: []
+          }
+        ]
+      ]);
+      /** @type {{ type: string, payload: unknown }[]} */
+      const calls = [];
+      const stores = {
+        /** @param {string} id */
+        snapshotFor(id) {
+          const issue = issues.get(id.replace('detail:', ''));
+          return issue ? [issue] : [];
+        },
+        subscribe() {
+          return () => {};
+        }
+      };
+      const view = createDetailView(
+        mount,
+        async (type, payload) => {
+          calls.push({ type, payload });
+          return { deleted: true };
+        },
+        undefined,
+        stores
+      );
+      await view.load('UI-OLD');
+      /** @type {HTMLButtonElement} */ (
+        mount.querySelector('.delete-issue-btn')
+      ).click();
+
+      await view.load('UI-NEW');
+      const dialog = /** @type {HTMLDialogElement} */ (
+        document.getElementById('delete-confirm-dialog')
+      );
+      /** @type {HTMLButtonElement} */ (
+        dialog.querySelector('#delete-confirm-btn')
+      ).click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(calls).toContainEqual({
+        type: 'delete-issue',
+        payload: { id: 'UI-OLD' }
+      });
+      expect(mount.textContent).toContain('New issue');
     });
   });
 });


### PR DESCRIPTION
## Summary

- render issue IDs and titles as inert lit-html values in the delete confirmation
- bind the native dialog cancel handler once and add accessible label relationships and initial focus
- retain the issue selected when confirmation opens so switching details cannot redirect the deletion

## Root cause

The confirmation dialog interpolated issue data into `innerHTML`, registered another native cancel listener on every open, and resolved the delete target from the current selection when confirmation completed.

## Validation

- `npm run all` (71 test files, 354 tests)
- `npm run build`