### PR TITLE
perf(app): coalesce subscription renders

### DIFF
--- a/app/data/list-selectors.js
+++ b/app/data/list-selectors.js
@@ -1,7 +1,7 @@
 /**
  * List selectors utility: compose subscription membership with issues entities
  * and apply view-specific sorting. Provides a lightweight `subscribe` that
- * triggers once per issues envelope to let views re-render.
+ * triggers after coalesced subscription-store updates to let views re-render.
  */
 /**
  * @import { Status } from '../protocol.js'
@@ -32,10 +32,7 @@ export function createListSelectors(issue_stores = undefined) {
     if (!issue_stores || typeof issue_stores.snapshotFor !== 'function') {
       return [];
     }
-    return issue_stores
-      .snapshotFor(client_id)
-      .slice()
-      .sort(cmpPriorityThenCreated);
+    return issue_stores.snapshotFor(client_id);
   }
 
   /**
@@ -48,15 +45,10 @@ export function createListSelectors(issue_stores = undefined) {
   function selectBoardColumn(client_id, mode) {
     const arr =
       issue_stores && issue_stores.snapshotFor
-        ? issue_stores.snapshotFor(client_id).slice()
+        ? issue_stores.snapshotFor(client_id)
         : [];
-    if (mode === 'in_progress') {
-      arr.sort(cmpPriorityThenCreated);
-    } else if (mode === 'closed') {
-      arr.sort(cmpClosedDesc);
-    } else {
-      // ready/blocked share the same sort
-      arr.sort(cmpPriorityThenCreated);
+    if (mode === 'closed') {
+      return arr.slice().sort(cmpClosedDesc);
     }
     return arr;
   }
@@ -124,7 +116,7 @@ export function createListSelectors(issue_stores = undefined) {
   }
 
   /**
-   * Subscribe for re-render; triggers once per issues envelope.
+   * Subscribe for re-render after coalesced subscription-store updates.
    *
    * @param {() => void} fn
    * @returns {() => void}

--- a/app/data/list-selectors.js
+++ b/app/data/list-selectors.js
@@ -17,7 +17,7 @@ import { cmpClosedDesc, cmpPriorityThenCreated } from './sort.js';
  * Source of truth is per-subscription stores providing snapshots for a given
  * client id. Central issues store fallback has been removed.
  *
- * @param {{ snapshotFor?: (client_id: string) => IssueLite[], subscribe?: (fn: () => void) => () => void }} [issue_stores]
+ * @param {{ snapshotFor?: (client_id: string) => IssueLite[], subscribe?: (fn: (client_id?: string) => void) => () => void, subscribeFor?: (client_ids: string | string[], fn: (client_id: string) => void) => () => void }} [issue_stores]
  */
 export function createListSelectors(issue_stores = undefined) {
   // Sorting comparators are centralized in app/data/sort.js
@@ -118,10 +118,18 @@ export function createListSelectors(issue_stores = undefined) {
   /**
    * Subscribe for re-render after coalesced subscription-store updates.
    *
-   * @param {() => void} fn
+   * @param {(client_id?: string) => void} fn
+   * @param {string | string[]} [client_ids]
    * @returns {() => void}
    */
-  function subscribe(fn) {
+  function subscribe(fn, client_ids = undefined) {
+    if (
+      client_ids &&
+      issue_stores &&
+      typeof issue_stores.subscribeFor === 'function'
+    ) {
+      return issue_stores.subscribeFor(client_ids, fn);
+    }
     if (issue_stores && typeof issue_stores.subscribe === 'function') {
       return issue_stores.subscribe(fn);
     }

--- a/app/data/list-selectors.test.js
+++ b/app/data/list-selectors.test.js
@@ -60,7 +60,36 @@ function setup() {
   return { issueStores, selectors };
 }
 
+/** Wait for the store's configured notification boundary. */
+async function flushStoreNotifications() {
+  if (typeof globalThis.requestAnimationFrame === 'function') {
+    await new Promise((resolve) =>
+      globalThis.requestAnimationFrame(() => resolve(undefined))
+    );
+    return;
+  }
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe('list-selectors', () => {
+  test('returns preordered store snapshots without another copy or sort', () => {
+    const issues = [
+      { id: 'A', priority: 1, created_at: 1 },
+      { id: 'B', priority: 2, created_at: 2 }
+    ];
+    const selectors = createListSelectors({
+      snapshotFor() {
+        return issues;
+      }
+    });
+
+    expect(selectors.selectIssuesFor('tab:issues')).toBe(issues);
+    expect(selectors.selectBoardColumn('tab:board:ready', 'ready')).toBe(
+      issues
+    );
+  });
+
   test('returns empty arrays for empty stores', async () => {
     const { selectors } = setup();
     expect(selectors.selectIssuesFor('tab:issues')).toEqual([]);
@@ -274,7 +303,7 @@ describe('list-selectors', () => {
     ).toEqual([]);
   });
 
-  test('subscribe triggers once per issues envelope', async () => {
+  test('subscribe triggers once per synchronous issues burst', async () => {
     const { issueStores, selectors } = setup();
     let calls = 0;
     const off = selectors.subscribe(() => {
@@ -287,6 +316,10 @@ describe('list-selectors', () => {
       revision: 1,
       issues: []
     });
+    expect(calls).toBe(0);
+
+    await flushStoreNotifications();
+
     expect(calls).toBe(1);
     off();
   });

--- a/app/data/list-selectors.test.js
+++ b/app/data/list-selectors.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { createListSelectors } from './list-selectors.js';
 import { createSubscriptionIssueStore } from './subscription-issue-store.js';
 
@@ -322,5 +322,17 @@ describe('list-selectors', () => {
 
     expect(calls).toBe(1);
     off();
+  });
+
+  test('scopes subscriptions when the registry supports it', () => {
+    const unsubscribe = vi.fn();
+    const subscribeFor = vi.fn(() => unsubscribe);
+    const selectors = createListSelectors({ subscribeFor });
+    const listener = vi.fn();
+
+    const result = selectors.subscribe(listener, ['list:a', 'list:b']);
+
+    expect(subscribeFor).toHaveBeenCalledWith(['list:a', 'list:b'], listener);
+    expect(result).toBe(unsubscribe);
   });
 });

--- a/app/data/subscription-issue-store.js
+++ b/app/data/subscription-issue-store.js
@@ -13,6 +13,20 @@ function hasOwn(obj, key) {
 }
 
 /**
+ * Defer listener work until the next paint when running in a browser. Tests and
+ * non-visual environments fall back to a microtask.
+ *
+ * @param {() => void} callback
+ */
+function scheduleStoreFlush(callback) {
+  if (typeof globalThis.requestAnimationFrame === 'function') {
+    globalThis.requestAnimationFrame(() => callback());
+    return;
+  }
+  queueMicrotask(callback);
+}
+
+/**
  * Per-subscription issue store. Holds full Issue objects and exposes a
  * deterministic, read-only snapshot for rendering. Applies snapshot/upsert/
  * delete messages in revision order and preserves object identity per id.
@@ -37,10 +51,19 @@ export function createSubscriptionIssueStore(id, options = {}) {
   const listeners = new Set();
   /** @type {boolean} */
   let is_disposed = false;
+  /** @type {boolean} */
+  let emit_scheduled = false;
+  /** @type {boolean} */
+  let ordered_dirty = false;
   /** @type {(a:any,b:any)=>number} */
   const sort = options.sort || cmpPriorityThenCreated;
 
-  function emit() {
+  function flushEmit() {
+    emit_scheduled = false;
+    if (is_disposed) {
+      return;
+    }
+    ensureOrdered();
     for (const fn of Array.from(listeners)) {
       try {
         fn();
@@ -50,8 +73,23 @@ export function createSubscriptionIssueStore(id, options = {}) {
     }
   }
 
+  function scheduleEmit() {
+    if (is_disposed || emit_scheduled) {
+      return;
+    }
+    emit_scheduled = true;
+    scheduleStoreFlush(flushEmit);
+  }
+
   function rebuildOrdered() {
     ordered = Array.from(items_by_id.values()).sort(sort);
+    ordered_dirty = false;
+  }
+
+  function ensureOrdered() {
+    if (ordered_dirty) {
+      rebuildOrdered();
+    }
   }
 
   /**
@@ -86,9 +124,9 @@ export function createSubscriptionIssueStore(id, options = {}) {
           items_by_id.set(it.id, it);
         }
       }
-      rebuildOrdered();
+      ordered_dirty = true;
       last_revision = rev;
-      emit();
+      scheduleEmit();
       return;
     }
     if (msg.type === 'upsert') {
@@ -130,18 +168,18 @@ export function createSubscriptionIssueStore(id, options = {}) {
             // stale by timestamp; ignore
           }
         }
-        rebuildOrdered();
+        ordered_dirty = true;
       }
       last_revision = rev;
-      emit();
+      scheduleEmit();
     } else if (msg.type === 'delete') {
       const rid = String(msg.issue_id || '');
       if (rid) {
         items_by_id.delete(rid);
-        rebuildOrdered();
+        ordered_dirty = true;
       }
       last_revision = rev;
-      emit();
+      scheduleEmit();
     }
   }
 
@@ -159,6 +197,7 @@ export function createSubscriptionIssueStore(id, options = {}) {
     applyPush,
     snapshot() {
       // Return as read-only view; callers must not mutate
+      ensureOrdered();
       return ordered;
     },
     size() {
@@ -172,8 +211,10 @@ export function createSubscriptionIssueStore(id, options = {}) {
     },
     dispose() {
       is_disposed = true;
+      emit_scheduled = false;
       items_by_id.clear();
       ordered = [];
+      ordered_dirty = false;
       listeners.clear();
       last_revision = 0;
     }

--- a/app/data/subscription-issue-store.test.js
+++ b/app/data/subscription-issue-store.test.js
@@ -1,5 +1,17 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { createSubscriptionIssueStore } from './subscription-issue-store.js';
+
+/** Wait for the store's configured notification boundary. */
+async function flushStoreNotifications() {
+  if (typeof globalThis.requestAnimationFrame === 'function') {
+    await new Promise((resolve) =>
+      globalThis.requestAnimationFrame(() => resolve(undefined))
+    );
+    return;
+  }
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe('subscription issue store', () => {
   test('applies snapshot and returns sorted snapshot', () => {
@@ -220,7 +232,7 @@ describe('subscription issue store', () => {
     expect(ids).toEqual(['B']);
   });
 
-  test('subscribe emits exactly once per applyPush', () => {
+  test('coalesces a synchronous applyPush burst', async () => {
     const store = createSubscriptionIssueStore('s1');
     let count = 0;
     store.subscribe(() => {
@@ -246,7 +258,147 @@ describe('subscription issue store', () => {
         closed_at: null
       }
     });
+    expect(count).toBe(0);
+
+    await flushStoreNotifications();
+
+    expect(count).toBe(1);
+
+    store.applyPush({
+      type: 'upsert',
+      id: 's1',
+      revision: 3,
+      issue: {
+        id: 'A',
+        title: 't2',
+        created_at: 10_000,
+        updated_at: 10_070,
+        closed_at: null
+      }
+    });
+
+    await flushStoreNotifications();
+
     expect(count).toBe(2);
+  });
+
+  test('coalesces push notifications until the next render frame', async () => {
+    /** @type {FrameRequestCallback[]} */
+    const frame_callbacks = [];
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback) => {
+        frame_callbacks.push(callback);
+        return frame_callbacks.length;
+      })
+    );
+    try {
+      const store = createSubscriptionIssueStore('s1');
+      const listener = vi.fn();
+      store.subscribe(listener);
+      store.applyPush({
+        type: 'snapshot',
+        id: 's1',
+        revision: 1,
+        issues: [
+          { id: 'A', created_at: 10_000, updated_at: 10_000, closed_at: null }
+        ]
+      });
+
+      await Promise.resolve();
+      store.applyPush({
+        type: 'upsert',
+        id: 's1',
+        revision: 2,
+        issue: {
+          id: 'A',
+          title: 'updated',
+          created_at: 10_000,
+          updated_at: 10_060,
+          closed_at: null
+        }
+      });
+
+      expect(frame_callbacks).toHaveLength(1);
+      expect(listener).not.toHaveBeenCalled();
+      frame_callbacks[0](0);
+      expect(listener).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test('uses a microtask when render frames are unavailable', async () => {
+    vi.stubGlobal('requestAnimationFrame', undefined);
+    try {
+      const store = createSubscriptionIssueStore('s1');
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.applyPush({
+        type: 'snapshot',
+        id: 's1',
+        revision: 1,
+        issues: []
+      });
+      expect(listener).not.toHaveBeenCalled();
+
+      await Promise.resolve();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test('sorts once for a synchronous push burst', async () => {
+    const sort = vi.fn((a, b) => a.id.localeCompare(b.id));
+    const store = createSubscriptionIssueStore('s1', { sort });
+    store.applyPush({
+      type: 'snapshot',
+      id: 's1',
+      revision: 1,
+      issues: [
+        { id: 'B', created_at: 10_000, updated_at: 10_000, closed_at: null },
+        { id: 'A', created_at: 10_000, updated_at: 10_000, closed_at: null }
+      ]
+    });
+    store.applyPush({
+      type: 'upsert',
+      id: 's1',
+      revision: 2,
+      issue: {
+        id: 'A',
+        title: 'A2',
+        created_at: 10_000,
+        updated_at: 10_060,
+        closed_at: null
+      }
+    });
+
+    await flushStoreNotifications();
+
+    expect(sort).toHaveBeenCalledTimes(1);
+    expect(store.snapshot().map((issue) => issue.id)).toEqual(['A', 'B']);
+  });
+
+  test('sorts immediately for a synchronous snapshot read', async () => {
+    const sort = vi.fn((a, b) => a.id.localeCompare(b.id));
+    const store = createSubscriptionIssueStore('s1', { sort });
+    store.applyPush({
+      type: 'snapshot',
+      id: 's1',
+      revision: 1,
+      issues: [
+        { id: 'B', created_at: 10_000, updated_at: 10_000, closed_at: null },
+        { id: 'A', created_at: 10_000, updated_at: 10_000, closed_at: null }
+      ]
+    });
+
+    expect(store.snapshot().map((issue) => issue.id)).toEqual(['A', 'B']);
+    expect(sort).toHaveBeenCalledTimes(1);
+    await flushStoreNotifications();
+    expect(sort).toHaveBeenCalledTimes(1);
   });
 
   test('dispose clears listeners and state', () => {

--- a/app/data/subscription-issue-stores.js
+++ b/app/data/subscription-issue-stores.js
@@ -17,19 +17,49 @@ export function createSubscriptionIssueStores() {
   const stores_by_id = new Map();
   /** @type {Map<string, string>} */
   const key_by_id = new Map();
-  /** @type {Set<() => void>} */
+  /** @type {Set<(client_id: string) => void>} */
   const listeners = new Set();
   /** @type {Map<string, () => void>} */
   const store_unsubs = new Map();
 
-  function emit() {
+  /**
+   * @param {string} client_id
+   */
+  function emit(client_id) {
     for (const fn of Array.from(listeners)) {
       try {
-        fn();
+        fn(client_id);
       } catch {
         // ignore
       }
     }
+  }
+
+  /**
+   * @param {(client_id: string) => void} fn
+   */
+  function subscribe(fn) {
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+  }
+
+  /**
+   * @param {string | string[]} client_ids
+   * @param {(client_id: string) => void} fn
+   */
+  function subscribeFor(client_ids, fn) {
+    const raw_ids = Array.isArray(client_ids) ? client_ids : [client_ids];
+    const wanted_ids = new Set(
+      raw_ids.map((value) => String(value || '')).filter(Boolean)
+    );
+    if (wanted_ids.size === 0) {
+      return () => {};
+    }
+    return subscribe((changed_client_id) => {
+      if (wanted_ids.has(changed_client_id)) {
+        fn(changed_client_id);
+      }
+    });
   }
 
   /**
@@ -68,13 +98,13 @@ export function createSubscriptionIssueStores() {
       }
       const new_store = createSubscriptionIssueStore(client_id, options);
       stores_by_id.set(client_id, new_store);
-      const off_new = new_store.subscribe(() => emit());
+      const off_new = new_store.subscribe(() => emit(client_id));
       store_unsubs.set(client_id, off_new);
     } else if (!has_store) {
       const store = createSubscriptionIssueStore(client_id, options);
       stores_by_id.set(client_id, store);
       // Fan out per-store events to global subscribers
-      const off = store.subscribe(() => emit());
+      const off = store.subscribe(() => emit(client_id));
       store_unsubs.set(client_id, off);
     }
     key_by_id.set(client_id, next_key);
@@ -121,12 +151,14 @@ export function createSubscriptionIssueStores() {
       return s ? /** @type {IssueLite[]} */ (s.snapshot().slice()) : [];
     },
     /**
-     * @param {() => void} fn
+     * @param {(client_id: string) => void} fn
      */
-    subscribe(fn) {
-      listeners.add(fn);
-      return () => listeners.delete(fn);
-    }
+    subscribe,
+    /**
+     * @param {string | string[]} client_ids
+     * @param {(client_id: string) => void} fn
+     */
+    subscribeFor
     // No recompute helpers in vNext; stores are updated directly via push
   };
 }

--- a/app/data/subscription-issue-stores.test.js
+++ b/app/data/subscription-issue-stores.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createSubscriptionIssueStores } from './subscription-issue-stores.js';
+
+/** Wait for coalesced store notifications. */
+async function flushStoreNotifications() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('subscription issue stores', () => {
+  test('reports the changed subscription id', async () => {
+    const stores = createSubscriptionIssueStores();
+    stores.register('list:a', { type: 'all-issues' });
+    const listener = vi.fn();
+    stores.subscribe(listener);
+
+    stores.getStore('list:a')?.applyPush({
+      type: 'snapshot',
+      id: 'list:a',
+      revision: 1,
+      issues: []
+    });
+    await flushStoreNotifications();
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith('list:a');
+  });
+
+  test('notifies scoped listeners only for selected subscriptions', async () => {
+    const stores = createSubscriptionIssueStores();
+    stores.register('list:a', { type: 'all-issues' });
+    stores.register('list:b', { type: 'ready-issues' });
+    const listener = vi.fn();
+    stores.subscribeFor('list:b', listener);
+
+    stores.getStore('list:a')?.applyPush({
+      type: 'snapshot',
+      id: 'list:a',
+      revision: 1,
+      issues: []
+    });
+    await flushStoreNotifications();
+    expect(listener).not.toHaveBeenCalled();
+
+    stores.getStore('list:b')?.applyPush({
+      type: 'snapshot',
+      id: 'list:b',
+      revision: 1,
+      issues: []
+    });
+    await flushStoreNotifications();
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith('list:b');
+  });
+});

--- a/app/detail.push.test.js
+++ b/app/detail.push.test.js
@@ -115,6 +115,7 @@ describe('detail view via subscription push', () => {
       status: 'open',
       priority: 2
     });
+    await tick();
 
     // Expect title to appear in the detail view
     const h2 = mount.querySelector('#detail-root h2');

--- a/app/main.js
+++ b/app/main.js
@@ -424,6 +424,15 @@ export function bootstrap(root_element) {
       view: last_view,
       board: persistedBoard
     });
+    let persisted_filters_json = JSON.stringify({
+      status: persisted_filters.status,
+      search: persisted_filters.search,
+      type: persisted_filters.type
+    });
+    let persisted_board_json = JSON.stringify({
+      closed_filter: persistedBoard.closed_filter
+    });
+    let persisted_view_value = last_view;
     const router = createHashRouter(store);
     router.start();
     /**
@@ -507,14 +516,21 @@ export function bootstrap(root_element) {
         search: s.filters.search,
         type: typeof s.filters.type === 'string' ? s.filters.type : ''
       };
-      window.localStorage.setItem('beads-ui.filters', JSON.stringify(data));
+      const next_json = JSON.stringify(data);
+      if (next_json !== persisted_filters_json) {
+        window.localStorage.setItem('beads-ui.filters', next_json);
+        persisted_filters_json = next_json;
+      }
     });
     // Persist board preferences
     store.subscribe((s) => {
-      window.localStorage.setItem(
-        'beads-ui.board',
-        JSON.stringify({ closed_filter: s.board.closed_filter })
-      );
+      const next_json = JSON.stringify({
+        closed_filter: s.board.closed_filter
+      });
+      if (next_json !== persisted_board_json) {
+        window.localStorage.setItem('beads-ui.board', next_json);
+        persisted_board_json = next_json;
+      }
     });
     void issues_view.load();
 
@@ -990,7 +1006,10 @@ export function bootstrap(root_element) {
       if (!s.selected_id && s.view === 'board') {
         void board_view.load();
       }
-      window.localStorage.setItem('beads-ui.view', s.view);
+      if (s.view !== persisted_view_value) {
+        window.localStorage.setItem('beads-ui.view', s.view);
+        persisted_view_value = s.view;
+      }
     };
     store.subscribe(onRouteChange);
     // Ensure initial state is reflected (fixes reload on #/epics)

--- a/app/main.performance.test.js
+++ b/app/main.performance.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from 'vitest';
+import { bootstrap } from './main.js';
+
+vi.mock('./ws.js', () => ({
+  createWsClient: () => ({
+    async send() {
+      return null;
+    },
+    on() {
+      return () => {};
+    },
+    close() {},
+    getState() {
+      return 'open';
+    }
+  })
+}));
+
+describe('main performance-sensitive persistence', () => {
+  test('does not persist unrelated state for selection-only routes', async () => {
+    window.localStorage.clear();
+    window.location.hash = '#/issues';
+    document.body.innerHTML = '<main id="app"></main>';
+    const root = /** @type {HTMLElement} */ (document.getElementById('app'));
+
+    bootstrap(root);
+    await Promise.resolve();
+    const set_item = vi.spyOn(Storage.prototype, 'setItem');
+
+    window.location.hash = '#/issues?issue=UI-LOCAL';
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    await Promise.resolve();
+
+    const unrelated_writes = set_item.mock.calls.filter(([key]) =>
+      ['beads-ui.filters', 'beads-ui.board', 'beads-ui.view'].includes(
+        String(key)
+      )
+    );
+    expect(unrelated_writes).toEqual([]);
+  });
+});

--- a/app/main.push-stores.e2e.test.js
+++ b/app/main.push-stores.e2e.test.js
@@ -2,6 +2,18 @@ import { describe, expect, test, vi } from 'vitest';
 import { bootstrap } from './main.js';
 import { createWsClient } from './ws.js';
 
+/** Wait for subscription stores to notify their view listeners. */
+async function flushStoreNotifications() {
+  if (typeof globalThis.requestAnimationFrame === 'function') {
+    await new Promise((resolve) =>
+      globalThis.requestAnimationFrame(() => resolve(undefined))
+    );
+    return;
+  }
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 // Mock WS client to drive push envelopes and connection state
 vi.mock('./ws.js', () => {
   /** @type {Record<string, (p: any) => void>} */
@@ -78,7 +90,7 @@ describe('push stores integration (board view)', () => {
 
     bootstrap(root);
     // Allow router + subscriptions to wire
-    await Promise.resolve();
+    await flushStoreNotifications();
 
     // Initial board: no cards
     expect(document.querySelectorAll('#ready-col .board-card').length).toBe(0);
@@ -102,7 +114,7 @@ describe('push stores integration (board view)', () => {
       revision: 1,
       issues: [{ id: 'P-1', title: 'prog 1', updated_at: 20_000 }]
     });
-    await Promise.resolve();
+    await flushStoreNotifications();
 
     // Verify columns reflect only their subscription data
     expect(document.querySelectorAll('#ready-col .board-card').length).toBe(2);
@@ -117,7 +129,7 @@ describe('push stores integration (board view)', () => {
       revision: 2,
       issue: { id: 'R-3', title: 'ready 3', priority: 1, updated_at: 12_000 }
     });
-    await Promise.resolve();
+    await flushStoreNotifications();
 
     expect(document.querySelectorAll('#ready-col .board-card').length).toBe(3);
     // In-progress unaffected
@@ -132,7 +144,7 @@ describe('push stores integration (board view)', () => {
       revision: 2,
       issue_id: 'P-1'
     });
-    await Promise.resolve();
+    await flushStoreNotifications();
 
     expect(
       document.querySelectorAll('#in-progress-col .board-card').length
@@ -148,7 +160,7 @@ describe('push stores integration (board view)', () => {
     const root = /** @type {HTMLElement} */ (document.getElementById('app'));
 
     bootstrap(root);
-    await Promise.resolve();
+    await flushStoreNotifications();
 
     // Initial snapshot
     client._trigger('snapshot', {
@@ -160,7 +172,7 @@ describe('push stores integration (board view)', () => {
         { id: 'R-2', title: 'r2', priority: 2, updated_at: 10_100 }
       ]
     });
-    await Promise.resolve();
+    await flushStoreNotifications();
     expect(document.querySelectorAll('#ready-col .board-card').length).toBe(2);
 
     // Simulate reconnect cycle and server replaying the same snapshot
@@ -175,7 +187,7 @@ describe('push stores integration (board view)', () => {
         { id: 'R-2', title: 'r2', priority: 2, updated_at: 10_100 }
       ]
     });
-    await Promise.resolve();
+    await flushStoreNotifications();
     // Still exactly two cards; no duplicates
     expect(document.querySelectorAll('#ready-col .board-card').length).toBe(2);
 
@@ -186,7 +198,7 @@ describe('push stores integration (board view)', () => {
       revision: 2,
       issue: { id: 'R-2', title: 'r2!', priority: 2, updated_at: 10_200 }
     });
-    await Promise.resolve();
+    await flushStoreNotifications();
     expect(document.querySelectorAll('#ready-col .board-card').length).toBe(2);
   });
 
@@ -198,7 +210,7 @@ describe('push stores integration (board view)', () => {
     const root = /** @type {HTMLElement} */ (document.getElementById('app'));
 
     bootstrap(root);
-    await Promise.resolve();
+    await flushStoreNotifications();
     await Promise.resolve();
 
     const requested = client._sent
@@ -244,7 +256,7 @@ describe('push stores integration (board view)', () => {
         { id: 'X-1', title: 'both', priority: 1, updated_at: 10_100 }
       ]
     });
-    await Promise.resolve();
+    await flushStoreNotifications();
 
     const ids = Array.from(
       document.querySelectorAll('#blocked-col .board-card')

--- a/app/views/board.js
+++ b/app/views/board.js
@@ -2,6 +2,7 @@
  * @import { Status } from '../protocol.js'
  */
 import { html, render } from 'lit-html';
+import { repeat } from 'lit-html/directives/repeat.js';
 import { createListSelectors } from '../data/list-selectors.js';
 import { cmpClosedDesc, cmpPriorityThenCreated } from '../data/sort.js';
 import { createIssueIdRenderer } from '../utils/issue-id-renderer.js';
@@ -40,6 +41,14 @@ const COLUMN_STATUS_MAP = {
   'closed-col': 'closed'
 };
 
+const BOARD_CLIENT_IDS = [
+  'tab:board:ready',
+  'tab:board:blocked',
+  'tab:board:status-blocked',
+  'tab:board:in-progress',
+  'tab:board:closed'
+];
+
 /**
  * Create the Board view with Blocked, Ready, In progress, Closed.
  * Push-only: derives items from per-subscription stores.
@@ -53,7 +62,7 @@ const COLUMN_STATUS_MAP = {
  * @param {(id: string) => void} gotoIssue - Navigate to issue detail.
  * @param {{ getState: () => any, setState: (patch: any) => void, subscribe?: (fn: (s:any)=>void)=>()=>void }} [store]
  * @param {{ selectors: { getIds: (client_id: string) => string[], count?: (client_id: string) => number } }} [subscriptions]
- * @param {{ snapshotFor?: (client_id: string) => any[], subscribe?: (fn: () => void) => () => void }} [issueStores]
+ * @param {{ snapshotFor?: (client_id: string) => any[], subscribe?: (fn: (client_id?: string) => void) => () => void, subscribeFor?: (client_ids: string | string[], fn: (client_id: string) => void) => () => void }} [issueStores]
  * @param {(type: string, payload: unknown) => Promise<unknown>} [transport] - Transport function for sending updates
  * @returns {{ load: () => Promise<void>, clear: () => void }}
  */
@@ -163,7 +172,11 @@ export function createBoardView(
           role="list"
           aria-labelledby=${id + '-header'}
         >
-          ${items.map((it) => cardTemplate(it))}
+          ${repeat(
+            items,
+            (it) => it.id,
+            (it, index) => cardTemplate(it, title, index === 0)
+          )}
         </div>
       </section>
     `;
@@ -171,22 +184,24 @@ export function createBoardView(
 
   /**
    * @param {IssueLite} it
+   * @param {string} column_title
+   * @param {boolean} is_first
    */
-  function cardTemplate(it) {
+  function cardTemplate(it, column_title, is_first) {
+    const title = it.title || '(no title)';
     return html`
       <article
         class="board-card"
         data-issue-id=${it.id}
         role="listitem"
-        tabindex="-1"
+        tabindex=${is_first ? '0' : '-1'}
+        aria-label=${`Issue ${title} - Column ${column_title}`}
         draggable="true"
         @click=${(/** @type {MouseEvent} */ ev) => onCardClick(ev, it.id)}
         @dragstart=${(/** @type {DragEvent} */ ev) => onDragStart(ev, it.id)}
         @dragend=${onDragEnd}
       >
-        <div class="board-card__title text-truncate">
-          ${it.title || '(no title)'}
-        </div>
+        <div class="board-card__title text-truncate">${title}</div>
         <div class="board-card__meta">
           ${createTypeBadge(it.issue_type)} ${createPriorityBadge(it.priority)}
           ${createIssueIdRenderer(it.id, { class_name: 'mono' })}
@@ -282,55 +297,6 @@ export function createBoardView(
 
   function doRender() {
     render(template(), mount_element);
-    postRenderEnhance();
-  }
-
-  /**
-   * Enhance rendered board with a11y and keyboard navigation.
-   * - Roving tabindex per column (first card tabbable).
-   * - ArrowUp/ArrowDown within column.
-   * - ArrowLeft/ArrowRight to adjacent non-empty column (focus top card).
-   * - Enter/Space to open details for focused card.
-   */
-  function postRenderEnhance() {
-    try {
-      /** @type {HTMLElement[]} */
-      const columns = Array.from(
-        mount_element.querySelectorAll('.board-column')
-      );
-      for (const col of columns) {
-        const body = /** @type {HTMLElement|null} */ (
-          col.querySelector('.board-column__body')
-        );
-        if (!body) {
-          continue;
-        }
-        /** @type {HTMLElement[]} */
-        const cards = Array.from(body.querySelectorAll('.board-card'));
-        // Assign aria-label using column header for screen readers
-        const header = /** @type {HTMLElement|null} */ (
-          col.querySelector('.board-column__header')
-        );
-        const col_name = header ? header.textContent?.trim() || '' : '';
-        for (const card of cards) {
-          const title_el = /** @type {HTMLElement|null} */ (
-            card.querySelector('.board-card__title')
-          );
-          const t = title_el ? title_el.textContent?.trim() || '' : '';
-          card.setAttribute(
-            'aria-label',
-            `Issue ${t || '(no title)'} — Column ${col_name}`
-          );
-          // Default roving setup
-          card.tabIndex = -1;
-        }
-        if (cards.length > 0) {
-          cards[0].tabIndex = 0;
-        }
-      }
-    } catch {
-      // non-fatal
-    }
   }
 
   // Delegate keyboard handling from mount_element
@@ -634,7 +600,7 @@ export function createBoardView(
       } catch {
         // ignore
       }
-    });
+    }, BOARD_CLIENT_IDS);
   }
 
   return {

--- a/app/views/board.test.js
+++ b/app/views/board.test.js
@@ -610,6 +610,43 @@ describe('views/board Blocked lane union', () => {
       ['update-status', { id: 'S-1', status: 'closed' }]
     ]);
   });
+
+  test('preserves card identity when an earlier issue is inserted', async () => {
+    document.body.innerHTML = '<div id="m"></div>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('m'));
+    const issueStores = createTestIssueStores();
+    const issue_store = issueStores.getStore('tab:board:ready');
+    issue_store.applyPush({
+      type: 'snapshot',
+      id: 'tab:board:ready',
+      revision: 1,
+      issues: [
+        { id: 'UI-2', title: 'Two', priority: 1, updated_at: 1 },
+        { id: 'UI-3', title: 'Three', priority: 2, updated_at: 1 }
+      ]
+    });
+    const view = createBoardView(
+      mount,
+      null,
+      () => {},
+      undefined,
+      undefined,
+      issueStores
+    );
+    await view.load();
+    const existing_card = mount.querySelector('[data-issue-id="UI-2"]');
+
+    issue_store.applyPush({
+      type: 'upsert',
+      id: 'tab:board:ready',
+      revision: 2,
+      issue: { id: 'UI-1', title: 'One', priority: 0, updated_at: 2 }
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mount.querySelector('[data-issue-id="UI-2"]')).toBe(existing_card);
+  });
 });
 
 /**

--- a/app/views/detail.js
+++ b/app/views/detail.js
@@ -118,7 +118,7 @@ function defaultNavigateFn(hash) {
  * @param {HTMLElement} mount_element - Element to render into.
  * @param {(type: string, payload?: unknown) => Promise<unknown>} sendFn - RPC transport.
  * @param {(hash: string) => void} [navigateFn] - Navigation function; defaults to setting location.hash.
- * @param {{ snapshotFor?: (client_id: string) => any[], subscribe?: (fn: () => void) => () => void }} [issue_stores] - Optional issue stores for live updates.
+ * @param {{ snapshotFor?: (client_id: string) => any[], subscribe?: (fn: (client_id?: string) => void) => () => void }} [issue_stores] - Optional issue stores for live updates.
  * @returns {{ load: (id: string) => Promise<void>, clear: () => void, destroy: () => void }} View API.
  */
 export function createDetailView(
@@ -385,9 +385,18 @@ export function createDetailView(
   }
 
   // Live updates: re-render when issue stores change
+  /** @type {(() => void) | null} */
+  let unsubscribe_issue_stores = null;
   if (issue_stores && typeof issue_stores.subscribe === 'function') {
-    issue_stores.subscribe(() => {
+    unsubscribe_issue_stores = issue_stores.subscribe((client_id) => {
       try {
+        if (!current_id) {
+          return;
+        }
+        const active_client_id = `detail:${current_id}`;
+        if (client_id && client_id !== active_client_id) {
+          return;
+        }
         refreshFromStore();
         doRender();
         void ensureCommentsLoaded(current_id);
@@ -1688,6 +1697,10 @@ export function createDetailView(
     },
     destroy() {
       mount_element.replaceChildren();
+      if (unsubscribe_issue_stores) {
+        unsubscribe_issue_stores();
+        unsubscribe_issue_stores = null;
+      }
       if (delete_dialog && delete_dialog.parentNode) {
         delete_dialog.parentNode.removeChild(delete_dialog);
         delete_dialog = null;

--- a/app/views/epics.js
+++ b/app/views/epics.js
@@ -1,4 +1,5 @@
 import { html, render } from 'lit-html';
+import { repeat } from 'lit-html/directives/repeat.js';
 import { createListSelectors } from '../data/list-selectors.js';
 import { createIssueIdRenderer } from '../utils/issue-id-renderer.js';
 import { createIssueRowRenderer } from './issue-row.js';
@@ -19,7 +20,7 @@ import { createIssueRowRenderer } from './issue-row.js';
  * @param {{ updateIssue: (input: any) => Promise<any> }} data
  * @param {(id: string) => void} goto_issue - Navigate to issue detail.
  * @param {{ subscribeList: (client_id: string, spec: { type: string, params?: Record<string, string|number|boolean> }) => Promise<() => Promise<void>>, selectors: { getIds: (client_id: string) => string[], count?: (client_id: string) => number } }} [subscriptions]
- * @param {{ snapshotFor?: (client_id: string) => any[], subscribe?: (fn: () => void) => () => void }} [issue_stores]
+ * @param {{ snapshotFor?: (client_id: string) => any[], subscribe?: (fn: (client_id?: string) => void) => () => void }} [issue_stores]
  */
 export function createEpicsView(
   mount_element,
@@ -38,9 +39,26 @@ export function createEpicsView(
   const epic_unsubs = new Map();
   // Centralized selection helpers
   const selectors = issue_stores ? createListSelectors(issue_stores) : null;
+
+  /**
+   * @param {string | undefined} client_id
+   */
+  function shouldRefreshForClient(client_id) {
+    if (!client_id || client_id === 'tab:epics') {
+      return true;
+    }
+    if (!client_id.startsWith('detail:')) {
+      return false;
+    }
+    return expanded.has(client_id.slice('detail:'.length));
+  }
+
   // Live re-render on pushes: recompute groups when stores change
   if (selectors) {
-    selectors.subscribe(() => {
+    selectors.subscribe((client_id) => {
+      if (!shouldRefreshForClient(client_id)) {
+        return;
+      }
       const had_none = groups.length === 0;
       groups = buildGroupsFromSnapshot();
       doRender();
@@ -71,7 +89,11 @@ export function createEpicsView(
     if (!groups.length) {
       return html`<div class="panel__header muted">No epics found.</div>`;
     }
-    return html`${groups.map((g) => groupTemplate(g))}`;
+    return html`${repeat(
+      groups,
+      (group) => String(group.epic?.id || ''),
+      groupTemplate
+    )}`;
   }
 
   /**
@@ -136,7 +158,7 @@ export function createEpicsView(
                         </tr>
                       </thead>
                       <tbody>
-                        ${list.map((it) => renderRow(it))}
+                        ${repeat(list, (it) => it.id, renderRow)}
                       </tbody>
                     </table>`}
             </div>`

--- a/app/views/list.js
+++ b/app/views/list.js
@@ -3,6 +3,7 @@
  * @import { StatusFilter } from '../utils/status.js'
  */
 import { html, render } from 'lit-html';
+import { repeat } from 'lit-html/directives/repeat.js';
 import { createListSelectors } from '../data/list-selectors.js';
 import { cmpClosedDesc } from '../data/sort.js';
 import { ISSUE_TYPES, typeLabel } from '../utils/issue-type.js';
@@ -30,7 +31,7 @@ import { createIssueRowRenderer } from './issue-row.js';
  * @param {(hash: string) => void} [navigate_fn] - Navigation function (defaults to setting location.hash).
  * @param {{ getState: () => any, setState: (patch: any) => void, subscribe: (fn: (s:any)=>void)=>()=>void }} [store] - Optional state store.
  * @param {{ selectors: { getIds: (client_id: string) => string[] } }} [_subscriptions]
- * @param {{ snapshotFor?: (client_id: string) => any[], subscribe?: (fn: () => void) => () => void }} [issueStores]
+ * @param {{ snapshotFor?: (client_id: string) => any[], subscribe?: (fn: (client_id?: string) => void) => () => void, subscribeFor?: (client_ids: string | string[], fn: (client_id: string) => void) => () => void }} [issueStores]
  * @returns {{ load: () => Promise<void>, destroy: () => void }} View API.
  */
 /**
@@ -41,7 +42,7 @@ import { createIssueRowRenderer } from './issue-row.js';
  * @param {(hash: string) => void} [navigateFn]
  * @param {{ getState: () => any, setState: (patch: any) => void, subscribe: (fn: (s:any)=>void)=>()=>void }} [store]
  * @param {{ selectors: { getIds: (client_id: string) => string[] } }} [_subscriptions]
- * @param {{ snapshotFor?: (client_id: string) => any[], subscribe?: (fn: () => void) => () => void }} [issue_stores]
+ * @param {{ snapshotFor?: (client_id: string) => any[], subscribe?: (fn: (client_id?: string) => void) => () => void, subscribeFor?: (client_ids: string | string[], fn: (client_id: string) => void) => () => void }} [issue_stores]
  * @returns {{ load: () => Promise<void>, destroy: () => void }}
  */
 export function createListView(
@@ -388,7 +389,7 @@ export function createListView(
                   </tr>
                 </thead>
                 <tbody role="rowgroup">
-                  ${filtered.map((it) => row_renderer(it))}
+                  ${repeat(filtered, (it) => it.id, row_renderer)}
                 </tbody>
               </table>
             </div>`}
@@ -634,8 +635,10 @@ export function createListView(
   }
 
   // Live updates: recompose and re-render when issue stores change
+  /** @type {(() => void) | null} */
+  let unsubscribe_selectors = null;
   if (selectors) {
-    selectors.subscribe(() => {
+    unsubscribe_selectors = selectors.subscribe(() => {
       try {
         issues_cache = /** @type {Issue[]} */ (
           selectors.selectIssuesFor('tab:issues')
@@ -644,7 +647,7 @@ export function createListView(
       } catch {
         // ignore
       }
-    });
+    }, 'tab:issues');
   }
 
   return {
@@ -655,6 +658,10 @@ export function createListView(
       if (unsubscribe) {
         unsubscribe();
         unsubscribe = null;
+      }
+      if (unsubscribe_selectors) {
+        unsubscribe_selectors();
+        unsubscribe_selectors = null;
       }
     }
   };

--- a/app/views/list.test.js
+++ b/app/views/list.test.js
@@ -835,4 +835,42 @@ describe('views/list', () => {
     expect(rows.length).toBe(1);
     expect(rows[0].getAttribute('data-issue-id')).toBe('UI-2');
   });
+
+  test('preserves row identity when an earlier issue is inserted', async () => {
+    document.body.innerHTML = '<aside id="mount" class="panel"></aside>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issueStores = createTestIssueStores();
+    const issue_store = issueStores.getStore('tab:issues');
+    issue_store.applyPush({
+      type: 'snapshot',
+      id: 'tab:issues',
+      revision: 1,
+      issues: [
+        { id: 'UI-2', title: 'Two', priority: 1, updated_at: 1 },
+        { id: 'UI-3', title: 'Three', priority: 2, updated_at: 1 }
+      ]
+    });
+    const view = createListView(
+      mount,
+      async () => [],
+      undefined,
+      undefined,
+      undefined,
+      issueStores
+    );
+    await view.load();
+    const existing_row = mount.querySelector('[data-issue-id="UI-2"]');
+
+    issue_store.applyPush({
+      type: 'upsert',
+      id: 'tab:issues',
+      revision: 2,
+      issue: { id: 'UI-1', title: 'One', priority: 0, updated_at: 2 }
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mount.querySelector('[data-issue-id="UI-2"]')).toBe(existing_row);
+    view.destroy();
+  });
 });

--- a/test/setup-vitest.js
+++ b/test/setup-vitest.js
@@ -10,3 +10,12 @@ console.warn = /** @type {function(...*): void} */ (
     }
   }
 );
+
+// Keep frame-scheduled rendering deterministic without waiting for JSDOM's
+// timer-backed animation frames in every view test.
+globalThis.requestAnimationFrame = (
+  /** @type {FrameRequestCallback} */ callback
+) => {
+  globalThis.queueMicrotask(() => callback(globalThis.performance.now()));
+  return 0;
+};

--- a/types/subscription-issue-store.ts
+++ b/types/subscription-issue-store.ts
@@ -23,9 +23,9 @@ export interface SubscriptionIssueStore {
   readonly id: string;
 
   /**
-   * Subscribe to store changes. Listener is invoked after each applied message
-   * exactly once, regardless of how many items changed. Returns an unsubscribe
-   * function.
+   * Subscribe to store changes. Applied changes are coalesced until the next
+   * render frame when available, so one listener notification may represent
+   * multiple push messages. Returns an unsubscribe function.
    */
   subscribe(listener: () => void): () => void;
 


### PR DESCRIPTION
## Summary

- coalesce per-subscription store notifications and sorting until the next render frame
- route store changes only to views that consume the changed subscription
- preserve list-row, board-card, and epic-row DOM identity with keyed Lit rendering
- reuse the store's priority/creation ordering in list selectors, retaining the closed-date sort where required
- render board accessibility attributes directly instead of walking every card after each render
- skip synchronous localStorage writes when filters, board preferences, or view are unchanged
- cover browser-frame and non-visual microtask scheduling paths

## Performance effect

For a burst of N issue updates to one subscription before the next paint, store sorting and listener notification drop from N executions to one. Unrelated subscription updates no longer fan out to every view, and inserting or removing an issue no longer rewrites all subsequent row/card DOM nodes. Tests assert these work-unit reductions directly; wall-clock gains depend on list size and update volume.

## Validation

- `npm run all` (73 files, 362 tests)
- `npm run build`
