### PR TITLE
perf(server): prioritize interactive detail reads

### DIFF
--- a/app/detail.push.test.js
+++ b/app/detail.push.test.js
@@ -115,6 +115,7 @@ describe('detail view via subscription push', () => {
       status: 'open',
       priority: 2
     });
+    await tick();
 
     // Expect title to appear in the detail view
     const h2 = mount.querySelector('#detail-root h2');
@@ -144,6 +145,89 @@ describe('detail view via subscription push', () => {
     expect(calls).toEqual([{ type: 'get-comments', payload: { id: 'UI-2' } }]);
     expect(mount.querySelectorAll('.comment-item').length).toBe(1);
     expect(mount.textContent).toContain('Fetched comment');
+  });
+
+  test('renders details while comments load in the background', async () => {
+    document.body.innerHTML = '<section id="mount"></section>';
+    const mount = /** @type {HTMLElement} */ (document.getElementById('mount'));
+    const issueStores = createSubscriptionIssueStores();
+    issueStores.register('detail:UI-2B', {
+      type: 'issue-detail',
+      params: { id: 'UI-2B' }
+    });
+    const store = issueStores.getStore('detail:UI-2B');
+    expect(store).not.toBeNull();
+    pushSnapshot(/** @type {NonNullable<typeof store>} */ (store), 'UI-2B', {
+      title: 'Available immediately'
+    });
+    const slow_comments = deferred();
+    const view = createDetailView(
+      mount,
+      async (type) => {
+        if (type === 'get-comments') {
+          return slow_comments.promise;
+        }
+        return {};
+      },
+      (hash) => (window.location.hash = hash),
+      issueStores
+    );
+
+    await view.load('UI-2B');
+
+    expect(mount.textContent).toContain('Available immediately');
+    expect(mount.textContent).toContain('Loading comments');
+
+    slow_comments.resolve([comment(1, 'Loaded later')]);
+    await tick();
+
+    expect(mount.textContent).toContain('Loaded later');
+  });
+
+  test('skips comment requests when the count is zero', async () => {
+    /** @type {Array<{type: string, payload: unknown}>} */
+    const calls = [];
+
+    const { mount, store } = await setupDetail(
+      'UI-2Z',
+      async (type, payload) => {
+        calls.push({ type, payload });
+        return {};
+      }
+    );
+
+    pushSnapshot(store, 'UI-2Z', {
+      title: 'No comments',
+      comment_count: 0
+    });
+    await tick();
+
+    expect(calls).toEqual([]);
+    expect(mount.textContent).toContain('No comments yet');
+  });
+
+  test('loads comments when the count increases from zero', async () => {
+    let fetch_count = 0;
+    const { mount, store } = await setupDetail('UI-2ZI', async (type) => {
+      if (type === 'get-comments') {
+        fetch_count += 1;
+        return [comment(1, 'Newly added comment')];
+      }
+      return {};
+    });
+
+    pushSnapshot(store, 'UI-2ZI', { comment_count: 0 });
+    await tick();
+    expect(fetch_count).toBe(0);
+
+    pushUpsert(store, 'UI-2ZI', 2, {
+      title: 'Comment added',
+      comment_count: 1
+    });
+    await tick();
+
+    expect(fetch_count).toBe(1);
+    expect(mount.textContent).toContain('Newly added comment');
   });
 
   test('keeps comments after later detail update omits comments', async () => {
@@ -243,7 +327,7 @@ describe('detail view via subscription push', () => {
     expect(mount.textContent).toContain('Complete replacement');
   });
 
-  test('retries comments after failed fetch clears in-flight state', async () => {
+  test('shows comment errors and retries on request', async () => {
     let fetch_count = 0;
 
     const { mount, store } = await setupDetail('UI-5', async (type) => {
@@ -260,9 +344,19 @@ describe('detail view via subscription push', () => {
     pushSnapshot(store, 'UI-5');
     await tick();
 
+    expect(fetch_count).toBe(1);
+    expect(mount.textContent).toContain('temporary failure');
+
     pushUpsert(store, 'UI-5', 2, {
       title: 'Retry'
     });
+    await tick();
+    expect(fetch_count).toBe(1);
+
+    const retry = /** @type {HTMLButtonElement | null} */ (
+      mount.querySelector('.comments button')
+    );
+    retry?.click();
     await tick();
 
     expect(fetch_count).toBe(2);

--- a/app/main.js
+++ b/app/main.js
@@ -532,12 +532,26 @@ export function bootstrap(root_element) {
       }
     });
 
+    /**
+     * Load comments outside the global activity indicator so a slow comments
+     * request does not keep the entire application in a loading state.
+     *
+     * @param {string} type
+     * @param {unknown} payload
+     */
+    const detail_transport = async (type, payload) => {
+      if (type === 'get-comments') {
+        return client.send(/** @type {MessageType} */ (type), payload);
+      }
+      return transport(type, payload);
+    };
+
     /** @type {ReturnType<typeof createDetailView> | null} */
     let detail = null;
     // Mount details into the dialog body only
     detail = createDetailView(
       dialog.getMount(),
-      transport,
+      detail_transport,
       (hash) => {
         const id = parseHash(hash);
         if (id) {

--- a/app/views/detail.js
+++ b/app/views/detail.js
@@ -156,6 +156,8 @@ export function createDetailView(
   const comments_loading = new Set();
   /** @type {Map<string, number>} */
   const comments_loaded_counts = new Map();
+  /** @type {Map<string, string>} */
+  const comments_load_errors = new Map();
 
   /** @type {HTMLDialogElement | null} */
   let delete_dialog = null;
@@ -308,6 +310,9 @@ export function createDetailView(
   function hasCurrentComments(issue) {
     const comments = /** @type {any} */ (issue).comments;
     if (!Array.isArray(comments)) {
+      if (issueCommentCount(issue) === 0) {
+        return true;
+      }
       return false;
     }
     const count = issueCommentCount(issue);
@@ -349,7 +354,8 @@ export function createDetailView(
       !current ||
       String(current.id) !== issue_id ||
       hasCurrentComments(current) ||
-      comments_loading.has(issue_id)
+      comments_loading.has(issue_id) ||
+      comments_load_errors.has(issue_id)
     ) {
       return;
     }
@@ -375,13 +381,45 @@ export function createDetailView(
         }
         /** @type {any} */ (current).comments = comments;
         markCommentsLoaded(current, comments, true);
+        comments_load_errors.delete(issue_id);
         doRender();
       }
     } catch (err) {
       log('fetch comments failed %s %o', issue_id, err);
+      comments_load_errors.set(issue_id, errorMessage(err));
     } finally {
       comments_loading.delete(issue_id);
+      if (
+        current &&
+        current_id === issue_id &&
+        String(current.id) === issue_id
+      ) {
+        doRender();
+      }
     }
+  }
+
+  /**
+   * @param {unknown} err
+   */
+  function errorMessage(err) {
+    if (err && typeof err === 'object') {
+      const maybe_message = /** @type {{ message?: unknown }} */ (err).message;
+      if (typeof maybe_message === 'string' && maybe_message.length > 0) {
+        return maybe_message;
+      }
+    }
+    return 'Unable to load comments';
+  }
+
+  /** Retry loading comments for the active issue. */
+  function onCommentsRetry() {
+    if (!current_id) {
+      return;
+    }
+    comments_load_errors.delete(current_id);
+    doRender();
+    void ensureCommentsLoaded(current_id);
   }
 
   // Live updates: re-render when issue stores change
@@ -973,6 +1011,7 @@ export function createDetailView(
         // Update comments in current issue
         /** @type {any} */ (current).comments = result;
         markCommentsLoaded(current, result, false);
+        comments_load_errors.delete(String(current.id));
         comment_text = '';
         doRender();
       }
@@ -1349,23 +1388,33 @@ export function createDetailView(
     const comments = Array.isArray(/** @type {any} */ (issue).comments)
       ? /** @type {Comment[]} */ (/** @type {any} */ (issue).comments)
       : [];
+    const comments_error = comments_load_errors.get(String(issue.id)) || '';
+    const comments_pending =
+      comments.length === 0 && !comments_error && !hasCurrentComments(issue);
     const comments_block = html`<div class="comments">
       <div class="props-card__title">Comments</div>
-      ${comments.length === 0
-        ? html`<div class="muted">No comments yet</div>`
-        : comments.map(
-            (c) => html`
-              <div class="comment-item">
-                <div class="comment-header">
-                  <span class="comment-author">${c.author || 'Unknown'}</span>
-                  <span class="comment-date"
-                    >${formatCommentDate(c.created_at)}</span
-                  >
+      ${comments_error
+        ? html`<div class="muted" role="alert">
+            ${comments_error}
+            <button type="button" @click=${onCommentsRetry}>Retry</button>
+          </div>`
+        : comments.length === 0
+          ? html`<div class="muted">
+              ${comments_pending ? 'Loading comments…' : 'No comments yet'}
+            </div>`
+          : comments.map(
+              (c) => html`
+                <div class="comment-item">
+                  <div class="comment-header">
+                    <span class="comment-author">${c.author || 'Unknown'}</span>
+                    <span class="comment-date"
+                      >${formatCommentDate(c.created_at)}</span
+                    >
+                  </div>
+                  <div class="comment-text">${c.text}</div>
                 </div>
-                <div class="comment-text">${c.text}</div>
-              </div>
-            `
-          )}
+              `
+            )}
       <div class="comment-input">
         <textarea
           placeholder="Add a comment... (Ctrl+Enter to submit)"
@@ -1679,11 +1728,15 @@ export function createDetailView(
       pending = false;
       comment_text = '';
       comment_pending = false;
+      comments_load_errors.delete(current_id);
       doRender();
 
-      await ensureCommentsLoaded(current_id);
+      void ensureCommentsLoaded(current_id);
     },
     clear() {
+      current_id = null;
+      current = null;
+      comments_load_errors.clear();
       renderPlaceholder('Select an issue to view details');
     },
     destroy() {

--- a/server/bd.js
+++ b/server/bd.js
@@ -3,8 +3,19 @@ import { resolveDbPath } from './db.js';
 import { debug } from './logging.js';
 
 const log = debug('bd');
-/** @type {Promise<void>} */
-let bd_run_queue = Promise.resolve();
+const BD_INTERACTIVE_BURST_LIMIT = 4;
+
+/**
+ * @typedef {'interactive' | 'background'} BdPriority
+ * @typedef {{ operation: () => Promise<any>, resolve: (value: any) => void, reject: (error: unknown) => void }} BdQueueTask
+ */
+
+/** @type {BdQueueTask[]} */
+const bd_queue_interactive = [];
+/** @type {BdQueueTask[]} */
+const bd_queue_background = [];
+let bd_queue_running = false;
+let bd_queue_interactive_burst = 0;
 
 /**
  * Get the git user name from git config.
@@ -57,11 +68,14 @@ export function getBdBin() {
  * Shell is not used to avoid injection; args must be pre-split.
  *
  * @param {string[]} args - Arguments to pass (e.g., ["list", "--json"]).
- * @param {{ cwd?: string, env?: Record<string, string | undefined>, timeout_ms?: number }} [options]
+ * @param {{ cwd?: string, env?: Record<string, string | undefined>, timeout_ms?: number, priority?: BdPriority }} [options]
  * @returns {Promise<{ code: number, stdout: string, stderr: string }>}
  */
 export function runBd(args, options = {}) {
-  return withBdRunQueue(async () => runBdUnlocked(args, options));
+  return withBdRunQueue(
+    async () => runBdUnlocked(args, options),
+    options.priority
+  );
 }
 
 /**
@@ -188,31 +202,73 @@ function buildBdArgs(args) {
  * Dolt embedded mode can crash when multiple `bd` processes run concurrently
  * against the same workspace.
  *
+ * Interactive work is dequeued before watcher-driven list refreshes. A bounded
+ * burst prevents background refreshes from starving under sustained activity.
+ *
  * @template T
  * @param {() => Promise<T>} operation
+ * @param {BdPriority} [priority]
  * @returns {Promise<T>}
  */
-async function withBdRunQueue(operation) {
-  const previous = bd_run_queue;
-  /** @type {() => void} */
-  let release = () => {};
-  bd_run_queue = new Promise((resolve) => {
-    release = resolve;
+function withBdRunQueue(operation, priority = 'interactive') {
+  return new Promise((resolve, reject) => {
+    const queue =
+      priority === 'background' ? bd_queue_background : bd_queue_interactive;
+    queue.push({ operation, resolve, reject });
+    void pumpBdQueue();
   });
+}
 
-  await previous.catch(() => {});
-  try {
-    return await operation();
-  } finally {
-    release();
+/** Drain queued bd operations one at a time. */
+async function pumpBdQueue() {
+  if (bd_queue_running) {
+    return;
   }
+  bd_queue_running = true;
+  try {
+    for (;;) {
+      const task = nextBdQueueTask();
+      if (!task) {
+        break;
+      }
+      try {
+        task.resolve(await task.operation());
+      } catch (err) {
+        task.reject(err);
+      }
+    }
+  } finally {
+    bd_queue_running = false;
+  }
+}
+
+/**
+ * Select the next task while keeping background work bounded.
+ *
+ * @returns {BdQueueTask | undefined}
+ */
+function nextBdQueueTask() {
+  if (bd_queue_interactive.length === 0) {
+    bd_queue_interactive_burst = 0;
+    return bd_queue_background.shift();
+  }
+  if (bd_queue_background.length === 0) {
+    bd_queue_interactive_burst = 0;
+    return bd_queue_interactive.shift();
+  }
+  if (bd_queue_interactive_burst >= BD_INTERACTIVE_BURST_LIMIT) {
+    bd_queue_interactive_burst = 0;
+    return bd_queue_background.shift();
+  }
+  bd_queue_interactive_burst += 1;
+  return bd_queue_interactive.shift();
 }
 
 /**
  * Run `bd` and parse JSON from stdout if exit code is 0.
  *
  * @param {string[]} args - Must include flags that cause JSON to be printed (e.g., `--json`).
- * @param {{ cwd?: string, env?: Record<string, string | undefined>, timeout_ms?: number }} [options]
+ * @param {{ cwd?: string, env?: Record<string, string | undefined>, timeout_ms?: number, priority?: BdPriority }} [options]
  * @returns {Promise<{ code: number, stdoutJson?: unknown, stderr?: string }>}
  */
 export async function runBdJson(args, options = {}) {

--- a/server/bd.test.js
+++ b/server/bd.test.js
@@ -36,6 +36,23 @@ function makeFakeProc(stdoutText, stderrText, code) {
   return cp;
 }
 
+/** Create a child process that closes only when directed by the test. */
+function makeControlledProc() {
+  const cp = /** @type {any} */ (new EventEmitter());
+  const out = new PassThrough();
+  const err = new PassThrough();
+  cp.stdout = out;
+  cp.stderr = err;
+  return {
+    cp,
+    close() {
+      out.end();
+      err.end();
+      cp.emit('close', 0);
+    }
+  };
+}
+
 const mockedSpawn = /** @type {import('vitest').Mock} */ (spawnMock);
 /** @type {string[]} */
 const temp_dirs = [];
@@ -44,6 +61,20 @@ function make_temp_dir() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bdui-bd-'));
   temp_dirs.push(dir);
   return dir;
+}
+
+/**
+ * @param {unknown[]} values
+ * @param {number} length
+ */
+async function waitForLength(values, length) {
+  for (let index = 0; index < 20; index += 1) {
+    if (values.length >= length) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(`timed out waiting for length ${length}`);
 }
 
 beforeEach(() => {
@@ -189,6 +220,125 @@ describe('runBd', () => {
         debug_mod.default.enable(prev_enabled);
       }
     }
+  });
+
+  test('runs interactive commands before queued background commands', async () => {
+    /** @type {string[]} */
+    const order = [];
+    mockedSpawn.mockImplementation((_bin, args) => {
+      const command = /** @type {string[]} */ (args)
+        .filter((arg) => arg !== '--sandbox')
+        .join(' ');
+      order.push(command);
+      return makeFakeProc('ok', '', 0);
+    });
+
+    const first = runBd(['list', 'background-1'], {
+      priority: 'background'
+    });
+    const second = runBd(['list', 'background-2'], {
+      priority: 'background'
+    });
+    const interactive = runBd(['show', 'interactive']);
+    await Promise.all([first, second, interactive]);
+
+    expect(order).toEqual([
+      'list background-1',
+      'show interactive',
+      'list background-2'
+    ]);
+  });
+
+  test('runs background commands after bounded interactive bursts', async () => {
+    /** @type {string[]} */
+    const order = [];
+    mockedSpawn.mockImplementation((_bin, args) => {
+      const command = /** @type {string[]} */ (args)
+        .filter((arg) => arg !== '--sandbox')
+        .join(' ');
+      order.push(command);
+      return makeFakeProc('ok', '', 0);
+    });
+
+    const first = runBd(['show', 'interactive-0']);
+    const background = runBd(['list', 'background'], {
+      priority: 'background'
+    });
+    const interactive = Array.from({ length: 5 }, (_value, index) =>
+      runBd(['show', `interactive-${index + 1}`])
+    );
+    await Promise.all([first, background, ...interactive]);
+
+    expect(order).toEqual([
+      'show interactive-0',
+      'show interactive-1',
+      'show interactive-2',
+      'show interactive-3',
+      'show interactive-4',
+      'list background',
+      'show interactive-5'
+    ]);
+  });
+
+  test('does not count bursts while no background work is waiting', async () => {
+    /** @type {string[]} */
+    const order = [];
+    /** @type {Array<() => void>} */
+    const close_spawned = [];
+    mockedSpawn.mockImplementation((_bin, args) => {
+      const command = /** @type {string[]} */ (args)
+        .filter((arg) => arg !== '--sandbox')
+        .join(' ');
+      order.push(command);
+      const proc = makeControlledProc();
+      close_spawned.push(proc.close);
+      return proc.cp;
+    });
+
+    const first = runBd(['show', 'interactive-0']);
+    const initial = Array.from({ length: 4 }, (_value, index) =>
+      runBd(['show', `interactive-${index + 1}`])
+    );
+    await waitForLength(order, 1);
+    for (let index = 0; index < 4; index += 1) {
+      close_spawned[index]();
+      await waitForLength(order, index + 2);
+    }
+
+    const background = runBd(['list', 'background'], {
+      priority: 'background'
+    });
+    const late_interactive = runBd(['show', 'interactive-5']);
+    close_spawned[4]();
+    await waitForLength(order, 6);
+    close_spawned[5]();
+    await waitForLength(order, 7);
+    close_spawned[6]();
+    await Promise.all([first, ...initial, background, late_interactive]);
+
+    expect(order).toEqual([
+      'show interactive-0',
+      'show interactive-1',
+      'show interactive-2',
+      'show interactive-3',
+      'show interactive-4',
+      'show interactive-5',
+      'list background'
+    ]);
+  });
+
+  test('continues after a queued operation rejects', async () => {
+    mockedSpawn
+      .mockImplementationOnce(() => {
+        throw new Error('spawn failed');
+      })
+      .mockReturnValueOnce(makeFakeProc('ok', '', 0));
+
+    const failed = runBd(['list', 'first'], { priority: 'background' });
+    const succeeded = runBd(['show', 'second']);
+
+    await expect(failed).rejects.toThrow('spawn failed');
+    await expect(succeeded).resolves.toMatchObject({ code: 0 });
   });
 });
 

--- a/server/list-adapters.js
+++ b/server/list-adapters.js
@@ -135,7 +135,7 @@ export function normalizeIssueList(value) {
  * Errors do not throw; they are surfaced as a structured object.
  *
  * @param {{ type: string, params?: Record<string, string | number | boolean> }} spec
- * @param {{ cwd?: string }} [options] - Optional working directory for bd command
+ * @param {{ cwd?: string, priority?: 'interactive' | 'background' }} [options] - Optional bd command settings
  * @returns {Promise<FetchListResultSuccess | FetchListResultFailure>}
  */
 export async function fetchListForSubscription(spec, options = {}) {
@@ -151,7 +151,10 @@ export async function fetchListForSubscription(spec, options = {}) {
   }
 
   try {
-    const res = await runBdJson(args, { cwd: options.cwd });
+    const res = await runBdJson(args, {
+      cwd: options.cwd,
+      priority: options.priority
+    });
     if (!res || res.code !== 0 || !('stdoutJson' in res)) {
       log(
         'bd failed for %o (args=%o) code=%s stderr=%s',

--- a/server/list-adapters.test.js
+++ b/server/list-adapters.test.js
@@ -126,6 +126,23 @@ describe('list adapters for subscription types', () => {
     }
   });
 
+  test('forwards bd scheduling priority', async () => {
+    /** @type {import('vitest').Mock} */ (runBdJson).mockResolvedValue({
+      code: 0,
+      stdoutJson: []
+    });
+
+    await fetchListForSubscription(
+      { type: 'all-issues' },
+      { cwd: '/workspace', priority: 'background' }
+    );
+
+    expect(runBdJson).toHaveBeenCalledWith(
+      ['list', '--json', '--tree=false', '--limit', '0'],
+      { cwd: '/workspace', priority: 'background' }
+    );
+  });
+
   test('filters tombstoned epics', async () => {
     /** @type {import('vitest').Mock} */ (runBdJson).mockResolvedValue({
       code: 0,

--- a/server/ws.detail-cache.test.js
+++ b/server/ws.detail-cache.test.js
@@ -1,0 +1,368 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { getGitUserName, runBd, runBdJson } from './bd.js';
+import { fetchListForSubscription } from './list-adapters.js';
+import { registry } from './subscriptions.js';
+import { handleMessage } from './ws.js';
+
+vi.mock('./bd.js', () => ({
+  runBd: vi.fn(),
+  runBdJson: vi.fn(),
+  getGitUserName: vi.fn()
+}));
+
+vi.mock('./list-adapters.js', () => ({
+  fetchListForSubscription: vi.fn()
+}));
+
+const mockedFetch = /** @type {import('vitest').Mock} */ (
+  fetchListForSubscription
+);
+const mockedRunBd = /** @type {import('vitest').Mock} */ (runBd);
+const mockedRunBdJson = /** @type {import('vitest').Mock} */ (runBdJson);
+const mockedGitUserName = /** @type {import('vitest').Mock} */ (getGitUserName);
+/** @type {string[]} */
+const temp_dirs = [];
+
+function createSocket() {
+  return {
+    sent: /** @type {string[]} */ ([]),
+    readyState: 1,
+    OPEN: 1,
+    /** @param {string} msg */
+    send(msg) {
+      this.sent.push(String(msg));
+    }
+  };
+}
+
+function makeTempWorkspace() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bdui-ws-'));
+  temp_dirs.push(dir);
+  return dir;
+}
+
+function deferred() {
+  /** @type {(value: any) => void} */
+  let resolve = () => {};
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * @param {ReturnType<typeof createSocket>} sock
+ * @param {string} issue_id
+ */
+async function subscribeDetail(sock, issue_id) {
+  await handleMessage(
+    /** @type {any} */ (sock),
+    Buffer.from(
+      JSON.stringify({
+        id: `sub-${issue_id}`,
+        type: /** @type {any} */ ('subscribe-list'),
+        payload: {
+          id: `detail:${issue_id}`,
+          type: 'issue-detail',
+          params: { id: issue_id }
+        }
+      })
+    )
+  );
+}
+
+/**
+ * @param {ReturnType<typeof createSocket>} sock
+ * @param {string} issue_id
+ * @param {string} req_id
+ */
+async function requestComments(sock, issue_id, req_id) {
+  await handleMessage(
+    /** @type {any} */ (sock),
+    Buffer.from(
+      JSON.stringify({
+        id: req_id,
+        type: /** @type {any} */ ('get-comments'),
+        payload: { id: issue_id }
+      })
+    )
+  );
+}
+
+/**
+ * @param {ReturnType<typeof createSocket>} sock
+ * @param {string} root_dir
+ */
+async function setWorkspace(sock, root_dir) {
+  await handleMessage(
+    /** @type {any} */ (sock),
+    Buffer.from(
+      JSON.stringify({
+        id: `workspace-${path.basename(root_dir)}`,
+        type: /** @type {any} */ ('set-workspace'),
+        payload: { path: root_dir }
+      })
+    )
+  );
+}
+
+/**
+ * @param {ReturnType<typeof createSocket>} sock
+ * @param {string} issue_id
+ */
+async function sendStatusMutation(sock, issue_id) {
+  await handleMessage(
+    /** @type {any} */ (sock),
+    Buffer.from(
+      JSON.stringify({
+        id: `mut-${issue_id}`,
+        type: /** @type {any} */ ('update-status'),
+        payload: { id: issue_id, status: 'closed' }
+      })
+    )
+  );
+}
+
+/**
+ * @param {string} issue_id
+ */
+function detailItems(issue_id) {
+  return [{ id: issue_id, updated_at: 1, closed_at: null }];
+}
+
+beforeEach(() => {
+  registry.clear();
+  mockedFetch.mockReset();
+  mockedRunBd.mockReset();
+  mockedRunBdJson.mockReset();
+  mockedGitUserName.mockReset();
+});
+
+afterEach(() => {
+  for (const dir of temp_dirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('issue-detail snapshot cache', () => {
+  test('serves a second subscription from cache', async () => {
+    const issue_id = 'CACHE-1';
+    mockedFetch.mockResolvedValue({ ok: true, items: detailItems(issue_id) });
+
+    const first_sock = createSocket();
+    await subscribeDetail(first_sock, issue_id);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+
+    const second_sock = createSocket();
+    await subscribeDetail(second_sock, issue_id);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+
+    const snapshot = second_sock.sent
+      .map((msg) => JSON.parse(msg))
+      .find((msg) => msg.type === 'snapshot');
+    expect(snapshot.payload.issues).toEqual(detailItems(issue_id));
+  });
+
+  test('invalidates cached details after mutations', async () => {
+    const issue_id = 'CACHE-2';
+    mockedFetch.mockResolvedValue({ ok: true, items: detailItems(issue_id) });
+    mockedRunBd.mockResolvedValue({ code: 0, stdout: '', stderr: '' });
+    mockedRunBdJson.mockResolvedValue({
+      code: 0,
+      stdoutJson: { id: issue_id, status: 'closed' }
+    });
+
+    const sock = createSocket();
+    await subscribeDetail(sock, issue_id);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+
+    await sendStatusMutation(sock, issue_id);
+
+    const second_sock = createSocket();
+    await subscribeDetail(second_sock, issue_id);
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('rejects stale in-flight detail cache writes', async () => {
+    const issue_id = 'CACHE-RACE-1';
+    const stale = deferred();
+    mockedFetch
+      .mockImplementationOnce(() => stale.promise)
+      .mockResolvedValue({ ok: true, items: detailItems(issue_id) });
+    mockedRunBd.mockResolvedValue({ code: 0, stdout: '', stderr: '' });
+    mockedRunBdJson.mockResolvedValue({
+      code: 0,
+      stdoutJson: { id: issue_id, status: 'closed' }
+    });
+
+    const first_sock = createSocket();
+    const first_subscribe = subscribeDetail(first_sock, issue_id);
+    await Promise.resolve();
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+
+    await sendStatusMutation(first_sock, issue_id);
+    stale.resolve({ ok: true, items: detailItems(issue_id) });
+    await first_subscribe;
+
+    const second_sock = createSocket();
+    await subscribeDetail(second_sock, issue_id);
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('isolates the same issue id across workspaces', async () => {
+    const first_root = makeTempWorkspace();
+    const second_root = makeTempWorkspace();
+    const issue_id = 'CACHE-WORKSPACE-1';
+    mockedFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        items: [{ ...detailItems(issue_id)[0], title: 'First workspace' }]
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        items: [{ ...detailItems(issue_id)[0], title: 'Second workspace' }]
+      });
+
+    const first_sock = createSocket();
+    await setWorkspace(first_sock, first_root);
+    await subscribeDetail(first_sock, issue_id);
+
+    const second_sock = createSocket();
+    await setWorkspace(second_sock, second_root);
+    await subscribeDetail(second_sock, issue_id);
+
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+    const snapshot = second_sock.sent
+      .map((msg) => JSON.parse(msg))
+      .find((msg) => msg.type === 'snapshot');
+    expect(snapshot.payload.issues[0].title).toBe('Second workspace');
+  });
+});
+
+describe('comments cache', () => {
+  test('serves repeat comment requests from cache', async () => {
+    const issue_id = 'CACHE-3';
+    const comments = [{ id: 1, issue_id, author: 'alice', text: 'hi' }];
+    mockedRunBdJson.mockResolvedValue({ code: 0, stdoutJson: comments });
+
+    const sock = createSocket();
+    await requestComments(sock, issue_id, 'req-1');
+    await requestComments(sock, issue_id, 'req-2');
+
+    expect(mockedRunBdJson).toHaveBeenCalledTimes(1);
+    const replies = sock.sent.map((msg) => JSON.parse(msg));
+    expect(replies[0].payload).toEqual(comments);
+    expect(replies[1].payload).toEqual(comments);
+  });
+
+  test('invalidates cached comments after mutations', async () => {
+    const issue_id = 'CACHE-4';
+    mockedRunBd.mockResolvedValue({ code: 0, stdout: '', stderr: '' });
+    mockedRunBdJson.mockResolvedValue({ code: 0, stdoutJson: [] });
+
+    const sock = createSocket();
+    await requestComments(sock, issue_id, 'req-1');
+    expect(mockedRunBdJson).toHaveBeenCalledTimes(1);
+
+    await sendStatusMutation(sock, issue_id);
+    mockedRunBdJson.mockClear();
+
+    await requestComments(sock, issue_id, 'req-2');
+    expect(mockedRunBdJson).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not cache failed comment requests', async () => {
+    const issue_id = 'CACHE-5';
+    mockedRunBdJson
+      .mockResolvedValueOnce({ code: 1, stderr: 'nope' })
+      .mockResolvedValueOnce({ code: 0, stdoutJson: [] });
+
+    const sock = createSocket();
+    await requestComments(sock, issue_id, 'req-1');
+    await requestComments(sock, issue_id, 'req-2');
+
+    expect(mockedRunBdJson).toHaveBeenCalledTimes(2);
+    const replies = sock.sent.map((msg) => JSON.parse(msg));
+    expect(replies[0].ok).toBe(false);
+    expect(replies[1].ok).toBe(true);
+  });
+
+  test('rejects stale in-flight comment cache writes', async () => {
+    const issue_id = 'CACHE-RACE-2';
+    const stale = deferred();
+    const stale_comments = [{ id: 1, issue_id, text: 'stale' }];
+    const fresh_comments = [{ id: 2, issue_id, text: 'fresh' }];
+    mockedRunBd.mockResolvedValue({ code: 0, stdout: '', stderr: '' });
+    mockedRunBdJson
+      .mockImplementationOnce(() => stale.promise)
+      .mockResolvedValueOnce({
+        code: 0,
+        stdoutJson: { id: issue_id, status: 'closed' }
+      })
+      .mockResolvedValueOnce({ code: 0, stdoutJson: fresh_comments });
+
+    const sock = createSocket();
+    const first_comments = requestComments(sock, issue_id, 'req-1');
+    await Promise.resolve();
+    expect(mockedRunBdJson).toHaveBeenCalledTimes(1);
+
+    await sendStatusMutation(sock, issue_id);
+    stale.resolve({ code: 0, stdoutJson: stale_comments });
+    await first_comments;
+
+    await requestComments(sock, issue_id, 'req-2');
+
+    expect(mockedRunBdJson).toHaveBeenCalledTimes(3);
+    const replies = sock.sent.map((msg) => JSON.parse(msg));
+    expect(replies[replies.length - 1].payload).toEqual(fresh_comments);
+  });
+
+  test('uses the selected workspace for comment requests', async () => {
+    const root_dir = makeTempWorkspace();
+    const issue_id = 'CACHE-CWD-1';
+    mockedRunBdJson.mockResolvedValue({ code: 0, stdoutJson: [] });
+
+    const sock = createSocket();
+    await setWorkspace(sock, root_dir);
+    await requestComments(sock, issue_id, 'req-cwd');
+
+    expect(mockedRunBdJson).toHaveBeenLastCalledWith(
+      ['comments', issue_id, '--json'],
+      { cwd: root_dir }
+    );
+  });
+
+  test('uses the selected workspace when adding comments', async () => {
+    const root_dir = makeTempWorkspace();
+    const issue_id = 'CACHE-CWD-2';
+    mockedGitUserName.mockResolvedValue('Alice');
+    mockedRunBd.mockResolvedValue({ code: 0, stdout: '', stderr: '' });
+    mockedRunBdJson.mockResolvedValue({ code: 0, stdoutJson: [] });
+
+    const sock = createSocket();
+    await setWorkspace(sock, root_dir);
+    await handleMessage(
+      /** @type {any} */ (sock),
+      Buffer.from(
+        JSON.stringify({
+          id: 'add-comment-cwd',
+          type: /** @type {any} */ ('add-comment'),
+          payload: { id: issue_id, text: 'hello' }
+        })
+      )
+    );
+
+    expect(mockedGitUserName).toHaveBeenCalledWith({ cwd: root_dir });
+    expect(mockedRunBd).toHaveBeenCalledWith(
+      ['comments', 'add', issue_id, 'hello', '--author', 'Alice'],
+      { cwd: root_dir }
+    );
+    expect(mockedRunBdJson).toHaveBeenLastCalledWith(
+      ['comments', issue_id, '--json'],
+      { cwd: root_dir }
+    );
+  });
+});

--- a/server/ws.js
+++ b/server/ws.js
@@ -343,8 +343,10 @@ function emitSubscriptionDelete(ws, client_id, key, issue_id) {
 async function refreshAndPublish(spec) {
   const key = keyOf(spec);
   await registry.withKeyLock(key, async () => {
+    const is_detail = String(spec.type) === 'issue-detail';
     const res = await fetchListForSubscription(spec, {
-      cwd: CURRENT_WORKSPACE?.root_dir
+      cwd: CURRENT_WORKSPACE?.root_dir,
+      priority: is_detail ? 'interactive' : 'background'
     });
     if (!res.ok) {
       log('refresh failed for %s: %s %o', key, res.error.message, res.error);

--- a/server/ws.js
+++ b/server/ws.js
@@ -23,6 +23,22 @@ import { validateSubscribeListPayload } from './validators.js';
 const log = debug('ws');
 
 /**
+ * @typedef {{ id: string, updated_at: number, closed_at: number | null } & Record<string, unknown>} SubscriptionIssue
+ * @typedef {Awaited<ReturnType<typeof fetchListForSubscription>>} FetchListResult
+ */
+
+/**
+ * Short-lived caches for issue detail snapshots and comments. Entries only
+ * live between database change events.
+ */
+/** @type {Map<string, { items: SubscriptionIssue[] }>} */
+const ISSUE_DETAIL_CACHE = new Map();
+/** @type {Map<string, unknown[]>} */
+const COMMENTS_CACHE = new Map();
+const DETAIL_CACHE_LIMIT = 500;
+let DETAIL_CACHE_GENERATION = 0;
+
+/**
  * Debounced refresh scheduling for active list subscriptions.
  * A trailing window coalesces rapid change bursts into a single refresh run.
  */
@@ -56,6 +72,7 @@ let MUTATION_GATE = null;
  * @param {number} [timeout_ms]
  */
 function triggerMutationRefreshOnce(timeout_ms = 500) {
+  clearDetailCaches();
   if (MUTATION_GATE) {
     return;
   }
@@ -143,6 +160,7 @@ function collectActiveListSpecs() {
  * Run refresh for all active list subscription specs and publish deltas.
  */
 async function refreshAllActiveListSubscriptions() {
+  clearDetailCaches();
   const specs = collectActiveListSpecs();
   // Run refreshes concurrently; locking is handled per key in the registry
   await Promise.all(
@@ -207,6 +225,98 @@ let CURRENT_WORKSPACE = null;
  * @type {{ rebind: (opts?: { root_dir?: string }) => void, path: string } | null}
  */
 let DB_WATCHER = null;
+
+/**
+ * Clear issue-detail and comments caches whenever the database may have
+ * changed. Incrementing the generation prevents stale in-flight reads from
+ * repopulating either cache.
+ */
+function clearDetailCaches() {
+  ISSUE_DETAIL_CACHE.clear();
+  COMMENTS_CACHE.clear();
+  DETAIL_CACHE_GENERATION += 1;
+}
+
+/**
+ * @param {string} issue_id
+ */
+function issueDetailCacheKey(issue_id) {
+  const root_dir = CURRENT_WORKSPACE?.root_dir || '';
+  const db_path = CURRENT_WORKSPACE?.db_path || '';
+  return `${root_dir}\0${db_path}\0${issue_id}`;
+}
+
+/**
+ * @template T
+ * @param {Map<string, T>} cache
+ * @param {number} limit
+ */
+function evictOldestCacheEntry(cache, limit) {
+  if (cache.size <= limit) {
+    return;
+  }
+  const oldest_key = cache.keys().next().value;
+  if (oldest_key !== undefined) {
+    cache.delete(oldest_key);
+  }
+}
+
+/**
+ * @param {{ type: string, params?: Record<string, string|number|boolean> }} spec
+ * @param {SubscriptionIssue[]} items
+ * @param {number} generation
+ */
+function populateIssueDetailCache(spec, items, generation) {
+  if (generation !== DETAIL_CACHE_GENERATION) {
+    return;
+  }
+  const issue_id = String(spec.params?.id || '').trim();
+  if (issue_id.length === 0) {
+    return;
+  }
+  ISSUE_DETAIL_CACHE.set(issueDetailCacheKey(issue_id), {
+    items: items.slice()
+  });
+  evictOldestCacheEntry(ISSUE_DETAIL_CACHE, DETAIL_CACHE_LIMIT);
+}
+
+/**
+ * @param {{ type: string, params?: Record<string, string|number|boolean> }} spec
+ * @returns {Promise<FetchListResult>}
+ */
+async function fetchCachedIssueDetail(spec) {
+  const issue_id = String(spec.params?.id || '').trim();
+  if (issue_id.length === 0) {
+    return fetchListForSubscription(spec, {
+      cwd: CURRENT_WORKSPACE?.root_dir
+    });
+  }
+  const cached = ISSUE_DETAIL_CACHE.get(issueDetailCacheKey(issue_id));
+  if (cached) {
+    return { ok: true, items: cached.items.slice() };
+  }
+  const generation = DETAIL_CACHE_GENERATION;
+  const result = await fetchListForSubscription(spec, {
+    cwd: CURRENT_WORKSPACE?.root_dir
+  });
+  if (result.ok) {
+    populateIssueDetailCache(spec, result.items, generation);
+  }
+  return result;
+}
+
+/**
+ * @param {{ type: string, params?: Record<string, string|number|boolean> }} spec
+ * @returns {Promise<FetchListResult>}
+ */
+function fetchInitialListForSubscription(spec) {
+  if (String(spec.type) === 'issue-detail') {
+    return fetchCachedIssueDetail(spec);
+  }
+  return fetchListForSubscription(spec, {
+    cwd: CURRENT_WORKSPACE?.root_dir
+  });
+}
 
 /**
  * Get or initialize the subscription state for a socket.
@@ -344,6 +454,7 @@ async function refreshAndPublish(spec) {
   const key = keyOf(spec);
   await registry.withKeyLock(key, async () => {
     const is_detail = String(spec.type) === 'issue-detail';
+    const detail_cache_generation = DETAIL_CACHE_GENERATION;
     const res = await fetchListForSubscription(spec, {
       cwd: CURRENT_WORKSPACE?.root_dir,
       priority: is_detail ? 'interactive' : 'background'
@@ -353,6 +464,9 @@ async function refreshAndPublish(spec) {
       return;
     }
     const items = applyClosedIssuesFilter(spec, res.items);
+    if (is_detail) {
+      populateIssueDetailCache(spec, items, detail_cache_generation);
+    }
     const prev_size = registry.get(key)?.itemsById.size || 0;
     const delta = registry.applyItems(key, items);
     const entry = registry.get(key);
@@ -440,6 +554,7 @@ export function attachWsServer(http_server, options = {}) {
     root_dir: initial_root,
     db_path: initial_db.path
   };
+  clearDetailCaches();
 
   if (options.watcher) {
     DB_WATCHER = options.watcher;
@@ -549,6 +664,7 @@ export function attachWsServer(http_server, options = {}) {
 
       // Clear existing registry entries and refresh all subscriptions
       registry.clear();
+      clearDetailCaches();
 
       // Broadcast workspace-changed event to all clients
       broadcast('workspace-changed', CURRENT_WORKSPACE);
@@ -646,12 +762,10 @@ export async function handleMessage(ws, data) {
       ws.send(JSON.stringify(makeError(req, code, message, details)));
     };
 
-    /** @type {Awaited<ReturnType<typeof fetchListForSubscription>> | null} */
+    /** @type {FetchListResult | null} */
     let initial = null;
     try {
-      initial = await fetchListForSubscription(spec, {
-        cwd: CURRENT_WORKSPACE?.root_dir
-      });
+      initial = await fetchInitialListForSubscription(spec);
     } catch (err) {
       log('subscribe-list snapshot error for %s: %o', key, err);
       const message =
@@ -763,6 +877,7 @@ export async function handleMessage(ws, data) {
       return;
     }
     // Pass empty string to clear assignee when requested
+    clearDetailCaches();
     const res = await runBd(['update', id, '--assignee', assignee], bd_options);
     if (res.code !== 0) {
       ws.send(
@@ -810,6 +925,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
+    clearDetailCaches();
     const res = await runBd(['update', id, '--status', status], bd_options);
     if (res.code !== 0) {
       ws.send(
@@ -856,6 +972,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
+    clearDetailCaches();
     const res = await runBd(
       ['update', id, '--priority', String(priority)],
       bd_options
@@ -911,6 +1028,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
+    clearDetailCaches();
     const res = await runBd(['update', id, '--type', type], bd_options);
     if (res.code !== 0) {
       ws.send(
@@ -975,6 +1093,7 @@ export async function handleMessage(ws, data) {
             : field === 'notes'
               ? '--notes'
               : '--design';
+    clearDetailCaches();
     const res = await runBd(['update', id, flag, value], bd_options);
     if (res.code !== 0) {
       ws.send(
@@ -1033,6 +1152,7 @@ export async function handleMessage(ws, data) {
     if (typeof description === 'string' && description.length > 0) {
       args.push('-d', description);
     }
+    clearDetailCaches();
     const res = await runBd(args, bd_options);
     if (res.code !== 0) {
       ws.send(
@@ -1071,6 +1191,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
+    clearDetailCaches();
     const res = await runBd(['dep', 'add', a, b], bd_options);
     if (res.code !== 0) {
       ws.send(
@@ -1115,6 +1236,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
+    clearDetailCaches();
     const res = await runBd(['dep', 'remove', a, b], bd_options);
     if (res.code !== 0) {
       ws.send(
@@ -1159,6 +1281,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
+    clearDetailCaches();
     const res = await runBd(['label', 'add', id, label.trim()], bd_options);
     if (res.code !== 0) {
       ws.send(
@@ -1202,6 +1325,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
+    clearDetailCaches();
     const res = await runBd(['label', 'remove', id, label.trim()], bd_options);
     if (res.code !== 0) {
       ws.send(
@@ -1236,6 +1360,13 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
+    const cache_key = issueDetailCacheKey(id);
+    const cached = COMMENTS_CACHE.get(cache_key);
+    if (cached !== undefined) {
+      ws.send(JSON.stringify(makeOk(req, cached)));
+      return;
+    }
+    const generation = DETAIL_CACHE_GENERATION;
     const res = await runBdJson(['comments', id, '--json'], bd_options);
     if (res.code !== 0) {
       ws.send(
@@ -1243,7 +1374,12 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    ws.send(JSON.stringify(makeOk(req, res.stdoutJson || [])));
+    const comments = Array.isArray(res.stdoutJson) ? res.stdoutJson : [];
+    if (generation === DETAIL_CACHE_GENERATION) {
+      COMMENTS_CACHE.set(cache_key, comments.slice());
+      evictOldestCacheEntry(COMMENTS_CACHE, DETAIL_CACHE_LIMIT);
+    }
+    ws.send(JSON.stringify(makeOk(req, comments)));
     return;
   }
 
@@ -1268,8 +1404,10 @@ export async function handleMessage(ws, data) {
       return;
     }
 
+    clearDetailCaches();
+
     // Get git user name for author attribution
-    const author = await getGitUserName();
+    const author = await getGitUserName(bd_options);
     const args = ['comments', 'add', id, text.trim()];
     if (author) {
       args.push('--author', author);
@@ -1282,8 +1420,10 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
+    clearDetailCaches();
 
     // Return updated comments list
+    const generation = DETAIL_CACHE_GENERATION;
     const comments = await runBdJson(['comments', id, '--json'], bd_options);
     if (comments.code !== 0) {
       ws.send(
@@ -1293,7 +1433,14 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
-    ws.send(JSON.stringify(makeOk(req, comments.stdoutJson || [])));
+    const comment_list = Array.isArray(comments.stdoutJson)
+      ? comments.stdoutJson
+      : [];
+    if (generation === DETAIL_CACHE_GENERATION) {
+      COMMENTS_CACHE.set(issueDetailCacheKey(id), comment_list.slice());
+      evictOldestCacheEntry(COMMENTS_CACHE, DETAIL_CACHE_LIMIT);
+    }
+    ws.send(JSON.stringify(makeOk(req, comment_list)));
     return;
   }
 
@@ -1308,6 +1455,7 @@ export async function handleMessage(ws, data) {
       );
       return;
     }
+    clearDetailCaches();
     const res = await runBd(['delete', id, '--force'], bd_options);
     if (res.code !== 0) {
       ws.send(
@@ -1393,6 +1541,7 @@ export async function handleMessage(ws, data) {
 
       // Clear existing registry entries
       registry.clear();
+      clearDetailCaches();
 
       // Schedule refresh of all active list subscriptions
       scheduleListRefresh();

--- a/server/ws.list-refresh.coalesce.test.js
+++ b/server/ws.list-refresh.coalesce.test.js
@@ -91,5 +91,53 @@ describe('ws list refresh coalescing', () => {
     // After debounce window, one refresh per active spec
     await vi.advanceTimersByTimeAsync(1);
     expect(mock.mock.calls.length).toBe(2);
+    expect(
+      mock.mock.calls.every((call) => call[1]?.priority === 'background')
+    ).toBe(true);
+  });
+
+  test('keeps visible detail refreshes interactive', async () => {
+    const server = createServer();
+    const { wss } = attachWsServer(server, {
+      path: '/ws',
+      heartbeat_ms: 10000,
+      refresh_debounce_ms: 50
+    });
+    const sock = {
+      sent: /** @type {string[]} */ ([]),
+      readyState: 1,
+      OPEN: 1,
+      /** @param {string} message */
+      send(message) {
+        this.sent.push(String(message));
+      }
+    };
+    wss.clients.add(/** @type {any} */ (sock));
+    await handleMessage(
+      /** @type {any} */ (sock),
+      Buffer.from(
+        JSON.stringify({
+          id: 'detail-sub',
+          type: /** @type {any} */ ('subscribe-list'),
+          payload: {
+            id: 'detail:UI-1',
+            type: 'issue-detail',
+            params: { id: 'UI-1' }
+          }
+        })
+      )
+    );
+    const mock = /** @type {import('vitest').Mock} */ (
+      fetchListForSubscription
+    );
+    mock.mockClear();
+
+    scheduleListRefresh();
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(mock).toHaveBeenCalledWith(
+      { type: 'issue-detail', params: { id: 'UI-1' } },
+      expect.objectContaining({ priority: 'interactive' })
+    );
   });
 });


### PR DESCRIPTION
## Summary

- keep `bd` commands serialized while prioritizing interactive detail, comment, and mutation work over watcher-driven list refreshes
- bound interactive bursts so background board/list refreshes cannot starve
- cache issue-detail and comment reads per workspace until a mutation, watcher refresh, or workspace change invalidates them
- guard cache writes with a generation counter so stale in-flight reads cannot repopulate invalidated entries
- render issue details without waiting for comments, skip comment reads when `comment_count` is zero, and show local comment load errors with retry

## Expected performance effect

- reopening an unchanged issue reuses its detail and comment snapshots instead of spawning additional `bd` processes
- a detail read queued behind board refresh work moves ahead of pending background commands while retaining single-process database safety
- slow comment reads no longer hold the global loading indicator or delay visible issue fields

## Validation

- `npm run all` (72 test files, 370 tests)
- `npm run build`
- independent Claude Opus 4.6 review at maximum effort; no accepted implementation defects, with added coverage for workspace cache isolation and zero-to-positive comment count transitions
